### PR TITLE
Can improvements

### DIFF
--- a/examples/can_print_auto/can_print_auto.c
+++ b/examples/can_print_auto/can_print_auto.c
@@ -3,29 +3,36 @@
 #include <can/can.h>
 
 void tx_callback(uint8_t*, uint8_t*);
+void rx_callback(uint8_t*, uint8_t);
 
 mob_t auto_mob = {
     .mob_num = 0,
     .mob_type = AUTO_MOB,
-    .dlc = 7,
+    .dlc = 6,
     .id_tag = { 0x0000 },
     .id_mask = { 0x0000 },
     .ctrl = {
         .rtr = 1,
         .rplv = 1
     },
-    .tx_data_cb = tx_callback,
+    .tx_data_cb = tx_callback
 };
 
 // on a remote frame, expect to send back a "hello!"
 void tx_callback(uint8_t* data, uint8_t* len) {
-  *len = 7;
-  char str[] = "Hello!";
+    static uint8_t k = 0;
 
-  for(uint8_t i = 0; i < *len; i++) {
-      data[i] = str[i];
-  }
-  print("%s\n",data);
+    if (k < 3) {
+        *len = 6;
+        char str[] = "Hello!";
+
+        for(uint8_t i = 0; i < *len; i++) {
+            data[i] = str[i];
+        }
+    } else {
+        *len = 0;
+    }
+    k += 1;
 }
 
 int main(void) {
@@ -36,6 +43,7 @@ int main(void) {
   init_auto_mob(&auto_mob);
 
   resume_mob(&auto_mob);
+  dump_mob(&auto_mob);
 
   while (1) {}
 }

--- a/examples/can_print_auto_remote/can_print_auto_remote.c
+++ b/examples/can_print_auto_remote/can_print_auto_remote.c
@@ -3,22 +3,51 @@
 #include <can/can.h>
 
 void tx_callback(uint8_t*, uint8_t*);
+void rx_callback(uint8_t*, uint8_t);
 
 mob_t tx_mob = {
     .mob_num = 0,
     .mob_type = TX_MOB,
-    .dlc = 7,
-    .id_tag = { 0x0000 },
+    .dlc = 6,
+    .id_tag = { 0x0001 },
     .id_mask = { 0x0000 },
     .ctrl = {
         .rtr = 1
     },
     .tx_data_cb = tx_callback,
+    .rx_cb = rx_callback
 };
+
+/*
+    Interesting note: when the remote frame is not serviced, this calls
+    the TX callback three times; looks like a bug
+*/
 
 // remote frames have no data
 void tx_callback(uint8_t* data, uint8_t* len) {
-  *len = 0;
+    static uint8_t k = 0;
+
+    if (k < 3) {
+        *len = 6;
+    } else {
+        *len = 0;
+    }
+    k += 1;
+
+    print("Remote frame sent\n");
+    print("Waiting for data frame\n");
+}
+
+/*
+   When a TX MOb sends a dataframe (i.e. the RTR bit is set)
+   CAN automatically transforms this MOb into an RX mob, and when a reply
+   is received, the RXOK flag is set. Thus TX MObs sending remote frames
+   must have the rx_cb set.
+*/
+
+void rx_callback(uint8_t* data, uint8_t len) {
+    print("Data frame received!\n");
+    print("%s\n", (char *) data);
 }
 
 int main(void) {

--- a/examples/can_print_multi_rx/can_print_multi_rx.c
+++ b/examples/can_print_multi_rx/can_print_multi_rx.c
@@ -1,0 +1,31 @@
+#include <uart/uart.h>
+#include <uart/log.h>
+#include <can/can.h>
+
+void rx_callback(uint8_t*, uint8_t);
+
+mob_t rx_mob = {
+    .mob_num = 0,
+    .mob_type = RX_MOB,
+    .dlc = 1,
+    .id_tag = { 0x0000 },
+    .id_mask = { 0x0000 },
+    .ctrl = default_rx_ctrl,
+    .rx_cb = rx_callback
+};
+
+void rx_callback(uint8_t* data, uint8_t len) {
+    print("TX received!\n");
+    print("%s\n", (char *) data);
+}
+
+int main(void) {
+    init_uart();
+    print("UART initialized\n");
+
+    init_can();
+    init_rx_mob(&rx_mob);
+
+    print("Waiting for TX\n");
+    while (1) {}
+}

--- a/examples/can_print_multi_rx/makefile
+++ b/examples/can_print_multi_rx/makefile
@@ -1,0 +1,2 @@
+PROG = can_print_multi_rx
+include ../makefile

--- a/examples/can_print_multi_tx/can_print_multi_tx.c
+++ b/examples/can_print_multi_tx/can_print_multi_tx.c
@@ -36,8 +36,11 @@ int main (void) {
 
     while (1) {
         resume_mob(&tx_mob_1);
+        while (!is_paused(&tx_mob_1)) {};
         _delay_ms(100);
+
         resume_mob(&tx_mob_2);
+        while (!is_paused(&tx_mob_2)) {};
         _delay_ms(100);
     };
 }
@@ -45,7 +48,7 @@ int main (void) {
 void tx_callback_1(uint8_t* data, uint8_t* len) {
     static uint32_t val_1 = 0;
     if (val_1 % 2 == 0) {
-        data[0] = 0x41;
+        data[0] = 0x41; // A
         *len = 1;
     } else {
         *len = 0;
@@ -57,7 +60,7 @@ void tx_callback_1(uint8_t* data, uint8_t* len) {
 void tx_callback_2(uint8_t* data, uint8_t* len) {
     static uint32_t val_2 = 0;
     if (val_2 % 2 == 0) {
-        data[0] = 0x42;
+        data[0] = 0x42; // B
         *len = 1;
     } else {
         *len = 0;

--- a/examples/can_print_multi_tx/can_print_multi_tx.c
+++ b/examples/can_print_multi_tx/can_print_multi_tx.c
@@ -2,6 +2,9 @@
 #include <uart/log.h>
 #include <can/can.h>
 
+#define F_CPU 8000000UL
+#include <util/delay.h>
+
 void tx_callback_1(uint8_t*, uint8_t*);
 void tx_callback_2(uint8_t*, uint8_t*);
 
@@ -11,7 +14,7 @@ mob_t tx_mob_1 = {
 	.mob_type = TX_MOB,
     .id_tag = { 0x0001 },
     .ctrl = default_tx_ctrl,
-    .tx_data_cb = tx_callback_1
+    .tx_data_cb = tx_callback_1,
 };
 
 mob_t tx_mob_2 = {
@@ -19,7 +22,7 @@ mob_t tx_mob_2 = {
 	.mob_type = TX_MOB,
     .id_tag = { 0x0002 },
     .ctrl = default_tx_ctrl,
-    .tx_data_cb = tx_callback_2
+    .tx_data_cb = tx_callback_2,
 };
 
 int main (void) {
@@ -31,9 +34,12 @@ int main (void) {
 	init_tx_mob(&tx_mob_1);
     init_tx_mob(&tx_mob_2);
 
-    resume_mob(&tx_mob_1);
-
-    while (1) {};
+    while (1) {
+        resume_mob(&tx_mob_1);
+        _delay_ms(100);
+        resume_mob(&tx_mob_2);
+        _delay_ms(100);
+    };
 }
 
 void tx_callback_1(uint8_t* data, uint8_t* len) {
@@ -43,7 +49,6 @@ void tx_callback_1(uint8_t* data, uint8_t* len) {
         *len = 1;
     } else {
         *len = 0;
-        resume_mob(&tx_mob_2);
     }
 
     val_1 += 1;
@@ -56,7 +61,7 @@ void tx_callback_2(uint8_t* data, uint8_t* len) {
         *len = 1;
     } else {
         *len = 0;
-        resume_mob(&tx_mob_1);
     }
+
     val_2 += 1;
 }

--- a/examples/can_print_multi_tx/can_print_multi_tx.c
+++ b/examples/can_print_multi_tx/can_print_multi_tx.c
@@ -1,0 +1,62 @@
+#include <uart/uart.h>
+#include <uart/log.h>
+#include <can/can.h>
+
+void tx_callback_1(uint8_t*, uint8_t*);
+void tx_callback_2(uint8_t*, uint8_t*);
+
+// this is a tx mob used for testing
+mob_t tx_mob_1 = {
+    .mob_num = 0,
+	.mob_type = TX_MOB,
+    .id_tag = { 0x0001 },
+    .ctrl = default_tx_ctrl,
+    .tx_data_cb = tx_callback_1
+};
+
+mob_t tx_mob_2 = {
+    .mob_num = 1,
+	.mob_type = TX_MOB,
+    .id_tag = { 0x0002 },
+    .ctrl = default_tx_ctrl,
+    .tx_data_cb = tx_callback_2
+};
+
+int main (void) {
+	init_uart();
+	print("UART Initialized\n");
+
+    init_can();
+
+	init_tx_mob(&tx_mob_1);
+    init_tx_mob(&tx_mob_2);
+
+    resume_mob(&tx_mob_1);
+
+    while (1) {};
+}
+
+void tx_callback_1(uint8_t* data, uint8_t* len) {
+    static uint32_t val_1 = 0;
+    if (val_1 % 2 == 0) {
+        data[0] = 0x41;
+        *len = 1;
+    } else {
+        *len = 0;
+        resume_mob(&tx_mob_2);
+    }
+
+    val_1 += 1;
+}
+
+void tx_callback_2(uint8_t* data, uint8_t* len) {
+    static uint32_t val_2 = 0;
+    if (val_2 % 2 == 0) {
+        data[0] = 0x42;
+        *len = 1;
+    } else {
+        *len = 0;
+        resume_mob(&tx_mob_1);
+    }
+    val_2 += 1;
+}

--- a/examples/can_print_multi_tx/makefile
+++ b/examples/can_print_multi_tx/makefile
@@ -1,0 +1,2 @@
+PROG = can_print_multi_tx
+include ../makefile

--- a/examples/can_print_tx/can_print_tx.c
+++ b/examples/can_print_tx/can_print_tx.c
@@ -28,9 +28,10 @@ int main(void) {
     init_can();
     init_tx_mob(&tx_mob);
 
-    resume_mob(&tx_mob);
-
     while (1) {
+        resume_mob(&tx_mob);
+        while (!is_paused(&tx_mob)) {};
+
         print("Status: %#02x\n", mob_status(&tx_mob));
         print("Tx error count: %d\n", CANTEC);
     }

--- a/examples/makefile
+++ b/examples/makefile
@@ -5,7 +5,12 @@ CFLAGS = -std=gnu99 -Wall -g -mmcu=atmega32m1 -Os -mcall-prologues
 
 PGMR = stk500
 MCU = m32m1
-PORT = COM3 #/dev/tty.usbmodem00187462
+
+ifeq ($(OS),Windows_NT)
+    PORT = COM3
+else
+    PORT = /dev/tty.usbmodem00187462
+endif
 
 $(PROG): $(PROG).o
 	$(CC) $(CFLAGS) -o $@.elf $^ $(LIB)

--- a/include/can/can.h
+++ b/include/can/can.h
@@ -59,3 +59,4 @@ void pause_mob(mob_t*);
 void resume_mob(mob_t*);
 
 uint8_t mob_status(mob_t*);
+void dump_mob(mob_t*);

--- a/include/can/can.h
+++ b/include/can/can.h
@@ -56,6 +56,8 @@ void init_tx_mob(mob_t*);
 void init_auto_mob(mob_t*);
 
 void pause_mob(mob_t*);
+uint8_t is_paused(mob_t*);
+
 void resume_mob(mob_t*);
 
 uint8_t mob_status(mob_t*);

--- a/src/can/can.c
+++ b/src/can/can.c
@@ -75,12 +75,13 @@ static inline void set_ctrl_flags(mob_ctrl_t ctrl) {
 }
 
 void load_data(mob_t* mob) {
-    select_mob(mob->mob_num);
-
     // load data from callback
     (mob->tx_data_cb)(mob->data, &(mob->dlc));
 
+    select_mob(mob->mob_num);
     uint8_t len = mob->dlc;
+
+    CANCDMOB &= ~(0x0f);
     CANCDMOB |= len;
 
     CANPAGE &= ~(0x07); // reset data buffer index

--- a/src/can/can.c
+++ b/src/can/can.c
@@ -7,7 +7,7 @@ static inline void select_mob(uint8_t mob_num) {
     CANPAGE = mob_num << 4;
 }
 
-void (mob_t* mob) {
+void dump_mob(mob_t* mob) {
     select_mob(mob->mob_num);
 
     print("----------------------------------------\n");


### PR DESCRIPTION
* Changed TX interrupt handling and resumption

Instead of being called after a successful TX (i.e. TXOK), the MOb is
automatically paused after handling a TX interrupt, and fresh data is
loaded on the next call to resume_mob().

To prevent resume_mob() from being called before the CAN transceiver
has had a chance to send the frame, the is_paused() method was also
added.

I expect this will be used as follows:

```
resume_mob(&tx_mob);
while(!is_paused(&tx_mob) {};
// the TX MOb successfully sent the frame
```

* Added multi_tx and multi_rx examples
* Added `dump_mob` function to inspect MOb contents and registers
* Modified `/examples` makefile to choose `PORT` based on OS

Things left to do:

- [x] Update examples to take into account new TX interrupt handling + resumption
- [x] Aesthetic fixes; some weird tabs creeping in