### PR TITLE
Code cleaning

### DIFF
--- a/.clang_complete
+++ b/.clang_complete
@@ -1,0 +1,4 @@
+-Iinclude/can
+-Iinclude/queue
+-Iinclude/spi
+-Iinclude/uart

--- a/examples/can_print_auto/can_print_auto.c
+++ b/examples/can_print_auto/can_print_auto.c
@@ -3,7 +3,6 @@
 #include <can/can.h>
 
 void tx_callback(uint8_t*, uint8_t*);
-void rx_callback(uint8_t*, uint8_t);
 
 mob_t auto_mob = {
     .mob_num = 0,
@@ -43,7 +42,6 @@ int main(void) {
   init_auto_mob(&auto_mob);
 
   resume_mob(&auto_mob);
-  dump_mob(&auto_mob);
 
   while (1) {}
 }

--- a/examples/can_print_auto_remote/can_print_auto_remote.c
+++ b/examples/can_print_auto_remote/can_print_auto_remote.c
@@ -3,7 +3,7 @@
 #include <can/can.h>
 
 void tx_callback(uint8_t*, uint8_t*);
-void rx_callback(uint8_t*, uint8_t);
+void rx_callback(const uint8_t*, uint8_t);
 
 mob_t tx_mob = {
     .mob_num = 0,
@@ -45,7 +45,7 @@ void tx_callback(uint8_t* data, uint8_t* len) {
    must have the rx_cb set.
 */
 
-void rx_callback(uint8_t* data, uint8_t len) {
+void rx_callback(const uint8_t* data, uint8_t len) {
     print("Data frame received!\n");
     print("%s\n", (char *) data);
 }

--- a/examples/can_print_multi_rx/can_print_multi_rx.c
+++ b/examples/can_print_multi_rx/can_print_multi_rx.c
@@ -2,7 +2,7 @@
 #include <uart/log.h>
 #include <can/can.h>
 
-void rx_callback(uint8_t*, uint8_t);
+void rx_callback(const uint8_t*, uint8_t);
 
 mob_t rx_mob = {
     .mob_num = 0,
@@ -14,7 +14,7 @@ mob_t rx_mob = {
     .rx_cb = rx_callback
 };
 
-void rx_callback(uint8_t* data, uint8_t len) {
+void rx_callback(const uint8_t* data, uint8_t len) {
     print("TX received!\n");
     print("%s\n", (char *) data);
 }

--- a/examples/can_print_multi_tx/can_print_multi_tx.c
+++ b/examples/can_print_multi_tx/can_print_multi_tx.c
@@ -11,7 +11,7 @@ void tx_callback_2(uint8_t*, uint8_t*);
 // this is a tx mob used for testing
 mob_t tx_mob_1 = {
     .mob_num = 0,
-	.mob_type = TX_MOB,
+    .mob_type = TX_MOB,
     .id_tag = { 0x0001 },
     .ctrl = default_tx_ctrl,
     .tx_data_cb = tx_callback_1,
@@ -19,19 +19,19 @@ mob_t tx_mob_1 = {
 
 mob_t tx_mob_2 = {
     .mob_num = 1,
-	.mob_type = TX_MOB,
+    .mob_type = TX_MOB,
     .id_tag = { 0x0002 },
     .ctrl = default_tx_ctrl,
     .tx_data_cb = tx_callback_2,
 };
 
 int main (void) {
-	init_uart();
-	print("UART Initialized\n");
+    init_uart();
+    print("UART Initialized\n");
 
     init_can();
 
-	init_tx_mob(&tx_mob_1);
+    init_tx_mob(&tx_mob_1);
     init_tx_mob(&tx_mob_2);
 
     while (1) {

--- a/examples/can_print_rx/can_print_rx.c
+++ b/examples/can_print_rx/can_print_rx.c
@@ -2,7 +2,7 @@
 #include <uart/log.h>
 #include <can/can.h>
 
-void rx_callback(uint8_t*, uint8_t);
+void rx_callback(const uint8_t*, uint8_t);
 
 mob_t rx_mob = {
     .mob_num = 0,
@@ -14,7 +14,7 @@ mob_t rx_mob = {
     .rx_cb = rx_callback
 };
 
-void rx_callback(uint8_t* data, uint8_t len) {
+void rx_callback(const uint8_t* data, uint8_t len) {
     print("TX received!\n");
     print("%s\n", (char *) data);
 }

--- a/examples/code_gen/code_gen.c
+++ b/examples/code_gen/code_gen.c
@@ -1,0 +1,9 @@
+#include <stdint.h>
+
+int main(void) {
+    volatile uint8_t j = 0;
+    for (uint8_t i = 0; i < 100; i++) {
+        j += i;
+    }
+    return 0;
+}

--- a/examples/code_gen/makefile
+++ b/examples/code_gen/makefile
@@ -1,0 +1,2 @@
+PROG = code_gen
+include ../makefile

--- a/examples/uart_echo/uart_echo.c
+++ b/examples/uart_echo/uart_echo.c
@@ -2,7 +2,7 @@
 
 void echo(uint8_t *buf, uint8_t len) {
     if (len == 10) {
-        for (int i = 0; i < len; i++)
+        for (uint8_t i = 0; i < len; i++)
             put_char(buf[i]);
         clear_rx_buffer();
     }

--- a/include/can/can.h
+++ b/include/can/can.h
@@ -29,7 +29,7 @@ typedef struct {
 #define default_rx_ctrl { 0, 0, 0, 0, 0, 0 }
 #define default_tx_ctrl { 0, 0, 0, 0, 0, 0 }
 
-typedef void (*can_rx_callback_t)(uint8_t*, uint8_t);
+typedef void (*can_rx_callback_t)(const uint8_t*, uint8_t);
 typedef void (*can_tx_callback_t)(uint8_t*, uint8_t*);
 
 typedef struct {
@@ -56,8 +56,7 @@ void init_tx_mob(mob_t*);
 void init_auto_mob(mob_t*);
 
 void pause_mob(mob_t*);
-uint8_t is_paused(mob_t*);
-
 void resume_mob(mob_t*);
+uint8_t is_paused(mob_t*);
 
 uint8_t mob_status(mob_t*);

--- a/include/can/can_ids.h
+++ b/include/can/can_ids.h
@@ -1,25 +1,25 @@
 /*
-	FILENAME: 			can_ids.h
-	DEPENDENCIES:		none
+    FILENAME:            can_ids.h
+    DEPENDENCIES:        none
 
-	DESCRIPTION:		Defines global definitions for use with CAN
-	AUTHORS:			Dylan Vogel, Ali Haydaroglu
-	DATE MODIFIED:		2018-01-12
-	NOTE:
+    DESCRIPTION:        Defines global definitions for use with CAN
+    AUTHORS:            Dylan Vogel, Ali Haydaroglu
+    DATE MODIFIED:      2018-01-12
+    NOTE:
 
-	REVISION HISTORY:
+    REVISION HISTORY:
 
-	2018-01-12:			DV: Fixed bugs, wrotes out binary strting under hex string
-	2018-01-08:			DV: Added initial command IDs and PAY sensor IDs
+    2018-01-12:          DV: Fixed bugs, wrotes out binary strting under hex string
+    2018-01-08:          DV: Added initial command IDs and PAY sensor IDs
 */
 
 // GLOBAL RX MASK
-#define CAN_RX_MASK_ID		{ 0x07F8 }
+#define CAN_RX_MASK_ID        { 0x07F8 }
 // 0b0 111 1111 1000
 
 /*
 ################################################################################
- 						OBC
+                         OBC
 ################################################################################
 */
 
@@ -48,63 +48,63 @@
 
 /*
 ################################################################################
- 						EPS
+                         EPS
 ################################################################################
 */
 // EPS MOB IDS
-#define EPS_STATUS_RX_MOB_ID	{ 0x0409 }
+#define EPS_STATUS_RX_MOB_ID    { 0x0409 }
 // 0b0 100 0000 1001
-#define EPS_STATUS_TX_MOB_ID	{ 0x0014 }
+#define EPS_STATUS_TX_MOB_ID    { 0x0014 }
 // 0b0 000 0001 0100
-#define EPS_CMD_TX_MOB_ID		{ 0x0024 }
+#define EPS_CMD_TX_MOB_ID       { 0x0024 }
 // 0b0 000 0010 0100
-#define EPS_CMD_RX_MOB_ID		{ 0x0481 }
+#define EPS_CMD_RX_MOB_ID       { 0x0481 }
 // 0b0 100 1000 0001
-#define EPS_DATA_TX_MOB_ID		{ 0x0104 }
+#define EPS_DATA_TX_MOB_ID      { 0x0104 }
 // 0b0 001 0000 0100
 
 // EPS COMMAND IDS
-#define EPS_HK_REQ 			0b00000001
-#define EPS_HK_SENSOR_REQ 	0b00000010
+#define EPS_HK_REQ             0b00000001
+#define EPS_HK_SENSOR_REQ     0b00000010
 
 // EPS SENSOR IDS
 
 /*
 ################################################################################
- 						PAY
+                         PAY
 ################################################################################
 */
 
 // PAY MOB IDS
-#define PAY_STATUS_RX_MOB_ID	{ 0x0209 }	// RX MObs should have reciever ID of board
+#define PAY_STATUS_RX_MOB_ID    { 0x0209 }    // RX MObs should have reciever ID of board
 //0b 0 010 0000 1001
-#define PAY_STATUS_TX_MOB_ID	{ 0x0012 }
+#define PAY_STATUS_TX_MOB_ID    { 0x0012 }
 //0b 0 000 0001 0010
-#define PAY_CMD_TX_MOB_ID		{ 0x0022 }
+#define PAY_CMD_TX_MOB_ID       { 0x0022 }
 // 0b 0 000 0010 0010
-#define PAY_CMD_RX_MOB_ID		{ 0x0241 }
+#define PAY_CMD_RX_MOB_ID       { 0x0241 }
 // 0b 0 010 0100 0001
-#define PAY_DATA_TX_MOB_ID		{ 0x0102 }
+#define PAY_DATA_TX_MOB_ID      { 0x0102 }
 // 0b 0 001 0000 0010
 
 // PAY COMMAND IDS
-#define PAY_HK_REQ			0b10000001
-#define PAY_HK_SENSOR_REQ	0b10000010
-#define PAY_SCI_REQ			0b10000011
-#define PAY_SCI_SENSOR_REQ	0b10000100
+#define PAY_HK_REQ           0b10000001
+#define PAY_HK_SENSOR_REQ    0b10000010
+#define PAY_SCI_REQ          0b10000011
+#define PAY_SCI_SENSOR_REQ   0b10000100
 
 
 // PAY SENSOR IDS
-#define PAY_TEMP_1			0b00000000
-#define PAY_PRES_1			0b00000001
-#define PAY_HUMID_1			0b00000010
-#define PAY_MF_TEMP_1		0b00000011
-#define PAY_MF_TEMP_2		0b00000100
-#define	PAY_MF_TEMP_3		0b00000101
+#define PAY_TEMP_1           0b00000000
+#define PAY_PRES_1           0b00000001
+#define PAY_HUMID_1          0b00000010
+#define PAY_MF_TEMP_1        0b00000011
+#define PAY_MF_TEMP_2        0b00000100
+#define PAY_MF_TEMP_3        0b00000101
 
 // Well numbering starts at 0 and counts up to 32
-#define PAY_WELL_OD_1		0b01000000
-#define PAY_WELL_FL_1		0b11000000
+#define PAY_WELL_OD_1        0b01000000
+#define PAY_WELL_FL_1        0b11000000
 
-#define PAY_WELL_OD_33		0b01100000
-#define PAY_WELL_FL_33		0b11100000
+#define PAY_WELL_OD_33       0b01100000
+#define PAY_WELL_FL_33       0b11100000

--- a/include/spi/spi.h
+++ b/include/spi/spi.h
@@ -1,5 +1,6 @@
 #include <avr/io.h>
 #include <avr/cpufunc.h> // for _NOP()
+#include <string.h>
 
 // SPCR bits
 #define SPIE 7 // enable spi interrupts
@@ -16,12 +17,12 @@
 #define WCOL 6 // write collision flag
 #define SPI2X 0 // double speed bit
 
-typedef volatile uint8_t* PIN;
-typedef volatile uint8_t* PORT;
+typedef volatile uint8_t* pint_t;
+typedef volatile uint8_t* port_t;
 
 void init_spi(void);
 uint8_t send_spi(uint8_t);
 
-void init_cs(int, PORT);
-void set_cs_low(int, PORT);
-void set_cs_high(int, PORT);
+void init_cs(uint8_t, port_t);
+void set_cs_low(uint8_t, port_t);
+void set_cs_high(uint8_t, port_t);

--- a/include/uart/log.h
+++ b/include/uart/log.h
@@ -3,6 +3,6 @@
 
 #include "uart.h"
 
-#define LOG_BUFFER_SIZE 80
+#define LOG_BUF_SIZE 50
 
 int print(char *, ...);

--- a/include/uart/uart.h
+++ b/include/uart/uart.h
@@ -20,4 +20,4 @@ void clear_rx_buffer();
 
 void put_char(const uint8_t);
 void init_uart();
-void send_uart(const uint8_t*);
+void send_uart(const uint8_t*, int);

--- a/include/uart/uart.h
+++ b/include/uart/uart.h
@@ -10,7 +10,6 @@
 #define UART_TX PD3
 #define UART_RX PD4
 
-
 typedef void(*global_rx_cb_t)(uint8_t*, uint8_t);
 void (*global_rx_cb)(uint8_t*, uint8_t);
 

--- a/makefile
+++ b/makefile
@@ -1,6 +1,7 @@
 SUBDIRS = $(addprefix src/,uart spi can timer queue)
+EXAMPLES = $(dir $(wildcard examples/*/.))
 
-.PHONY: all $(SUBDIRS) clean
+.PHONY: all $(SUBDIRS) clean examples
 
 export CC = avr-gcc
 export AR = avr-ar
@@ -20,3 +21,11 @@ clean:
 
 $(SUBDIRS):
 	@$(MAKE) -e -C $@
+
+examples:
+	@for dir in $(EXAMPLES) ; do \
+		cd $$dir ; \
+		make clean ; \
+		make ; \
+		cd ../.. ; \
+	done

--- a/makefile
+++ b/makefile
@@ -7,7 +7,7 @@ export AR = avr-ar
 export RANLIB = avr-ranlib
 export INCLUDES = -I../../include
 #export LDFLAGS = -L../../lib
-export CFLAGS = -std=gnu99 -g -mmcu=atmega32m1 -Os -mcall-prologues
+export CFLAGS = -Wall -std=gnu99 -g -mmcu=atmega32m1 -Os -mcall-prologues
 
 all: $(SUBDIRS)
 

--- a/src/can/can.c
+++ b/src/can/can.c
@@ -1,6 +1,8 @@
 #include <can/can.h>
 #include <uart/log.h>
 
+#define ERR_MSG "ERR: %s.\n"
+
 mob_t* mob_array[6] = {0};
 
 static inline void select_mob(uint8_t mob_num) {
@@ -178,7 +180,7 @@ void init_auto_mob(mob_t* mob) {
 }
 
 void handle_rx_interrupt(mob_t* mob) {
-    print("Handling RX interrupt\n");
+    print("Handling %s interrupt\n", "RX");
 
     select_mob(mob->mob_num);
 
@@ -208,7 +210,7 @@ void handle_rx_interrupt(mob_t* mob) {
 }
 
 void handle_tx_interrupt(mob_t* mob) {
-    print("Handling TX interrupt\n");
+    print("Handling %s interrupt\n", "TX");
 
     /* TODO: Add some kind of burst mode, which looks like:
     // Try to load more data automatically
@@ -233,7 +235,7 @@ void handle_tx_interrupt(mob_t* mob) {
 }
 
 void handle_auto_tx_interrupt(mob_t* mob) {
-    print("Handling AUTO TX interrupt\n");
+    print("Handling %s interrupt\n", "AUTO TX");
 
     select_mob(mob->mob_num);
 
@@ -274,17 +276,23 @@ uint8_t handle_err(mob_t* mob) {
 
     if (err != 0) {
         if (err & _BV(DLCW)) {
-            print("ERR: Incoming message did not have expected DLC.\n");
+            print(ERR_MSG, "Bad DLC");
+            //print("ERR: Incoming message did not have expected DLC.\n");
         } else if (err & _BV(BERR)) {
-            print("ERR: Bit error.\n");
+            print(ERR_MSG, "Bit error");
+            //print("ERR: Bit error.\n");
         } else if (err & _BV(SERR)) {
-            print("ERR: Five consecutive bits with same polarity.\n");
+            print(ERR_MSG, "Bit stuffing error");
+            //print("ERR: Five consecutive bits with same polarity.\n");
         } else if (err & _BV(CERR)) {
-            print("ERR: CRC mismatch.\n");
+            print(ERR_MSG, "CRC mismatch");
+            //print("ERR: CRC mismatch.\n");
         } else if (err & _BV(FERR)) {
-            print("ERR: Form error.\n");
+            print(ERR_MSG, "Form error");
+            //print("ERR: Form error.\n");
         } else if (err & _BV(AERR)) {
-            print("ERR: No acknowledgement.\n");
+            print(ERR_MSG, "No ack");
+            //print("ERR: No acknowledgement.\n");
         }
 
         // TODO: is this the best way to handle errors?

--- a/src/can/can.c
+++ b/src/can/can.c
@@ -326,6 +326,10 @@ ISR(CAN_INT_vect){
                 case AUTO_MOB:
                     handle_auto_tx_interrupt(mob);
                     break;
+                default:
+                    // should never get here
+                    handle_err(mob);
+                    break;
             }
         }
     }

--- a/src/spi/spi.c
+++ b/src/spi/spi.c
@@ -6,15 +6,15 @@
 #define MOSI PB1
 #define SS PD3
 
-void init_cs(int pin, PORT ddr) {
+void init_cs(uint8_t pin, port_t ddr) {
     *ddr |= _BV(pin);
 }
 
-void set_cs_low(int pin, PORT port) {
+void set_cs_low(uint8_t pin, port_t port) {
     *port &= ~(_BV(pin));
 }
 
-void set_cs_high(int pin, PORT port) {
+void set_cs_high(uint8_t pin, port_t port) {
     *port |= _BV(pin);
 }
 

--- a/src/timer/timer.c
+++ b/src/timer/timer.c
@@ -8,49 +8,49 @@
 static Timer timer;
 
 void set_vars(uint8_t minutes, Command cmd){
-	uint32_t delay = minutes * 60L * 1000L;  // delay in ms
-	timer.ints = ((delay / MAX_TIME));
-	timer.count = ((delay - (timer.ints * MAX_TIME)) / T) + ROUND;
-	timer.cmd = cmd;
+    uint32_t delay = minutes * 60L * 1000L;  // delay in ms
+    timer.ints = ((delay / MAX_TIME));
+    timer.count = ((delay - (timer.ints * MAX_TIME)) / T) + ROUND;
+    timer.cmd = cmd;
 }
 
 void init_timer(uint8_t minutes, Command cmd){
-	set_vars(minutes, cmd);
+    set_vars(minutes, cmd);
 
-	// set timer to CTC mode - using OCR1A
-	TCCR1A &= ~(_BV(WGM10) | _BV(WGM11));
-	TCCR1B |= _BV(WGM12);
-	TCCR1B &= ~_BV(WGM13);
+    // set timer to CTC mode - using OCR1A
+    TCCR1A &= ~(_BV(WGM10) | _BV(WGM11));
+    TCCR1B |= _BV(WGM12);
+    TCCR1B &= ~_BV(WGM13);
 
-	// set timer to use internal clock with prescaler of 1024
-	TCCR1B |= _BV(CS12) | _BV(CS10);
-	TCCR1B &= ~_BV(CS11);
+    // set timer to use internal clock with prescaler of 1024
+    TCCR1B |= _BV(CS12) | _BV(CS10);
+    TCCR1B &= ~_BV(CS11);
 
-	// disable use of Output compare pins so that they can be used as normal pins
-	TCCR1A &= ~(_BV(COM1A1) | _BV(COM1A0) | _BV(COM1B1) | _BV(COM1B0));
+    // disable use of Output compare pins so that they can be used as normal pins
+    TCCR1A &= ~(_BV(COM1A1) | _BV(COM1A0) | _BV(COM1B1) | _BV(COM1B0));
 
-	TCNT1 = 0;  // initialize counter at 0
-	OCR1A = 0xFFFF;  // set compare value
+    TCNT1 = 0;  // initialize counter at 0
+    OCR1A = 0xFFFF;  // set compare value
 
-	// enable output compare interupt
-	TIMSK1 |= _BV(OCIE1A);
-	sei(); // enable global interrupts
+    // enable output compare interupt
+    TIMSK1 |= _BV(OCIE1A);
+    sei(); // enable global interrupts
 }
 
 volatile uint32_t counter = 0;  // the number of interrupts that have occured
 // This ISR occurs when TCNT1 is equal to OCR1A
 ISR(TIMER1_COMPA_vect){
 
-	counter++;
+    counter++;
 
-	if(counter == timer.ints){
-		OCR1A = timer.count;
-	}
-	else if(counter >= timer.ints + 1){  // the desired time has passed
-		counter = 0;
-		OCR1A = 0xFFFF;
+    if(counter == timer.ints){
+        OCR1A = timer.count;
+    }
+    else if(counter >= timer.ints + 1){  // the desired time has passed
+        counter = 0;
+        OCR1A = 0xFFFF;
 
-		(*(timer.cmd))();
+        (*(timer.cmd))();
 
-	}
+    }
 }

--- a/src/uart/log.c
+++ b/src/uart/log.c
@@ -1,16 +1,16 @@
 #include <uart/log.h>
 
 // TODO: should this be volatile
-uint8_t buf[LOG_BUFFER_SIZE];
+uint8_t log_buf[LOG_BUF_SIZE];
 
 // UART must be initialized before calling print
 inline int print(char *str, ...) {
     va_list ptr;
     va_start(ptr, str);
 
-    int ret = vsprintf((char *)buf, str, ptr);
+    int ret = vsprintf((char *)log_buf, str, ptr);
     va_end(ptr);
 
-    send_uart(buf, strlen((char*)buf));
+    send_uart(log_buf, strlen((char*)log_buf));
     return ret;
 }

--- a/src/uart/log.c
+++ b/src/uart/log.c
@@ -1,14 +1,16 @@
 #include <uart/log.h>
 
-char buf[LOG_BUFFER_SIZE];
+// TODO: should this be volatile
+uint8_t buf[LOG_BUFFER_SIZE];
+
 // UART must be initialized before calling print
 inline int print(char *str, ...) {
     va_list ptr;
     va_start(ptr, str);
 
-    int ret = vsprintf(buf, str, ptr);
+    int ret = vsprintf((char *)buf, str, ptr);
     va_end(ptr);
 
-    send_uart(buf);
+    send_uart(buf, strlen((char*)buf));
     return ret;
 }


### PR DESCRIPTION
Lots of small changes:

* Add new command `make examples` to test all examples at once
* Update CAN rx callback type to specify input data as `const`
* Minor update to UART library to make it more consistent; send_uart now takes a length argument
* Convert ints to uint8_t to save space
* Convert tabs to spaces
* Compile lib-common with -Wall
* Fix bad naming