### PR TITLE
Code cleanup - guard headers, CAN printing

### DIFF
--- a/include/can/can.h
+++ b/include/can/can.h
@@ -1,3 +1,6 @@
+#ifndef CAN_H
+#define CAN_H
+
 #include <avr/io.h>
 #include <avr/interrupt.h>
 
@@ -60,3 +63,5 @@ void resume_mob(mob_t*);
 uint8_t is_paused(mob_t*);
 
 uint8_t mob_status(mob_t*);
+
+#endif

--- a/include/queue/queue.h
+++ b/include/queue/queue.h
@@ -1,10 +1,13 @@
+#ifndef QUEUE_H
+#define QUEUE_H
+
 /*
     AUTHORS: J. W. Sheridan, Siddharth Mahendraker, Shimi Smith
 */
 
 #include <stdint.h>
 
-#define MAX_QUEUE_SIZE 10
+#define MAX_QUEUE_SIZE 5
 #define QUEUE_DATA_SIZE 8
 
 typedef struct {
@@ -19,3 +22,5 @@ uint8_t is_full(queue_t*);
 uint8_t is_empty(queue_t*);
 uint8_t enqueue(queue_t*, uint8_t*);
 uint8_t dequeue(queue_t*, uint8_t*);
+
+#endif

--- a/include/spi/spi.h
+++ b/include/spi/spi.h
@@ -1,3 +1,6 @@
+#ifndef SPI_H
+#define SPI_H
+
 #include <avr/io.h>
 #include <avr/cpufunc.h> // for _NOP()
 #include <string.h>
@@ -26,3 +29,5 @@ uint8_t send_spi(uint8_t);
 void init_cs(uint8_t, port_t);
 void set_cs_low(uint8_t, port_t);
 void set_cs_high(uint8_t, port_t);
+
+#endif

--- a/include/stack/stack.h
+++ b/include/stack/stack.h
@@ -1,3 +1,6 @@
+#ifndef STACK_H
+#define STACK_H
+
 /*
     AUTHORS: Siddharth Mahendraker, Shimi Smith, J. W. Sheridan
 */
@@ -18,3 +21,5 @@ uint8_t is_full(stack_t*);
 uint8_t is_empty(stack_t*);
 uint8_t push(stack_t*, uint8_t*);
 uint8_t pop(stack_t*, uint8_t*);
+
+#endif

--- a/include/test/test.h
+++ b/include/test/test.h
@@ -1,3 +1,6 @@
+#ifndef TEST_H
+#define TEST_H
+
 #include <avr/io.h>
 #include <stdint.h>
 
@@ -18,3 +21,5 @@ typedef struct {
 void run_tests(test_t**, uint8_t);
 
 void run_slave(void);
+
+#endif

--- a/include/timer/timer.h
+++ b/include/timer/timer.h
@@ -1,3 +1,6 @@
+#ifndef TIMER_H
+#define TIMER_H
+
 /*
 Authors: Shimi Smith, Matthew Silverman
 
@@ -41,3 +44,4 @@ typedef struct {
     // The command to run once the desired time has passed
 } timer_t;
 
+#endif

--- a/src/can/can.c
+++ b/src/can/can.c
@@ -54,10 +54,6 @@ uint8_t load_data(mob_t* mob) {
         CANMSG = (mob->data)[i]; // data buffer index auto-incremented
     }
 
-    if (len) {
-        print("Loaded data: %s len: %d\n", (char*) mob->data, mob->dlc);
-    }
-
     return len;
 }
 
@@ -103,7 +99,6 @@ void pause_mob(mob_t* mob) {
     select_mob(mob->mob_num);
 
     CANCDMOB &= ~(_BV(CONMOB0) | _BV(CONMOB1));
-    print("Mob %d paused\n", mob->mob_num);
 }
 
 
@@ -124,8 +119,6 @@ void resume_mob(mob_t* mob) {
             CANCDMOB &= ~(_BV(CONMOB0));
             break;
     }
-
-    print("Mob %d resumed\n", mob->mob_num);
 }
 
 void init_rx_mob(mob_t* mob) {
@@ -180,8 +173,6 @@ void init_auto_mob(mob_t* mob) {
 }
 
 void handle_rx_interrupt(mob_t* mob) {
-    print("Handling %s interrupt\n", "RX");
-
     select_mob(mob->mob_num);
 
     // we must reset the ID and various flags because they
@@ -210,8 +201,6 @@ void handle_rx_interrupt(mob_t* mob) {
 }
 
 void handle_tx_interrupt(mob_t* mob) {
-    print("Handling %s interrupt\n", "TX");
-
     /* TODO: Add some kind of burst mode, which looks like:
     // Try to load more data automatically
     load_data(mob);
@@ -235,8 +224,6 @@ void handle_tx_interrupt(mob_t* mob) {
 }
 
 void handle_auto_tx_interrupt(mob_t* mob) {
-    print("Handling %s interrupt\n", "AUTO TX");
-
     select_mob(mob->mob_num);
 
     // TODO: Many of the variables, including IDTAG, dlc, etc
@@ -277,22 +264,16 @@ uint8_t handle_err(mob_t* mob) {
     if (err != 0) {
         if (err & _BV(DLCW)) {
             print(ERR_MSG, "Bad DLC");
-            //print("ERR: Incoming message did not have expected DLC.\n");
         } else if (err & _BV(BERR)) {
             print(ERR_MSG, "Bit error");
-            //print("ERR: Bit error.\n");
         } else if (err & _BV(SERR)) {
             print(ERR_MSG, "Bit stuffing error");
-            //print("ERR: Five consecutive bits with same polarity.\n");
         } else if (err & _BV(CERR)) {
             print(ERR_MSG, "CRC mismatch");
-            //print("ERR: CRC mismatch.\n");
         } else if (err & _BV(FERR)) {
             print(ERR_MSG, "Form error");
-            //print("ERR: Form error.\n");
         } else if (err & _BV(AERR)) {
             print(ERR_MSG, "No ack");
-            //print("ERR: No acknowledgement.\n");
         }
 
         // TODO: is this the best way to handle errors?
@@ -304,7 +285,6 @@ uint8_t handle_err(mob_t* mob) {
 }
 
 ISR(CAN_INT_vect) {
-    print("Interrupt received\n");
     for (uint8_t i = 0; i < 6; i++) {
         mob_t* mob = mob_array[i];
 
@@ -312,7 +292,6 @@ ISR(CAN_INT_vect) {
         else select_mob(i);
 
         uint8_t status = mob_status(mob);
-        print("Status: %#.2x\n", status);
 
         if (handle_err(mob)) continue;
 


### PR DESCRIPTION
- Guard headers for header files prevent errors/warnings from redefining constants and redeclaring functions
- Commented out debugging print statements for CAN because they clutter a lot of the UART output when using the CAN library