### PR TITLE
Added print_bytes() utility function

### DIFF
--- a/include/uart/uart.h
+++ b/include/uart/uart.h
@@ -29,5 +29,6 @@ void send_uart(const uint8_t*, int);
 // Printing
 int print(char*, ...);
 int uprintf(char*, ...);
+void print_bytes(uint8_t*, uint8_t);
 
 #endif // UART_H

--- a/src/uart/log.c
+++ b/src/uart/log.c
@@ -24,3 +24,11 @@ inline int uprintf(char* str, ...) {
     send_uart(print_buf, strlen((char*)print_buf));
     return ret;
 }
+
+void print_bytes(uint8_t* data, uint8_t len) {
+    for (uint8_t i = 0; i < len; i++) {
+        print("0x%.2x ", data[i]);
+    }
+
+    print("\n");
+}


### PR DESCRIPTION
* The function print_bytes() takes an input an array of uint8_t's and a
length, and prints a hex formatted version of the contents of the array.