### PR TITLE
Watchdog Timer Library and Test Suite

### DIFF
--- a/bin/harness.py
+++ b/bin/harness.py
@@ -107,7 +107,7 @@ class TestSuite:
     mcu = "m32m1"
     prog = "stk500"
     includes = "-I./include/"
-    lib = "-L./lib/ -ltest -lprintf_flt -lm -luart -lspi -lcan -ltimer -lqueue -lstack -lheartbeat"
+    lib = "-L./lib/ -ltest -lprintf_flt -lm -luart -lspi -lcan -ltimer -lqueue -lstack -lheartbeat -lwatchdog"
 
     def __init__(self, path, boards, harness):
         self.path = path

--- a/build/watchdog/.gitignore
+++ b/build/watchdog/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/func_tests/makefile
+++ b/func_tests/makefile
@@ -1,6 +1,6 @@
 CC = avr-gcc
 INCLUDES = -I../../include
-LIB = -L../../lib -lprintf_flt -lm -ladc -luart -lspi -lcan -lqueue -lstack -ltimer -lheartbeat -lconversions -lpex -ldac
+LIB = -L../../lib -lprintf_flt -lm -ladc -luart -lspi -lcan -lqueue -lstack -ltimer -lheartbeat -lconversions -lpex -ldac lwatchdog
 CFLAGS = -std=gnu99 -Wall -Wl,-u,vfprintf -g -mmcu=atmega32m1 -Os -mcall-prologues
 
 PGMR = stk500

--- a/func_tests/makefile
+++ b/func_tests/makefile
@@ -1,6 +1,6 @@
 CC = avr-gcc
 INCLUDES = -I../../include
-LIB = -L../../lib -lprintf_flt -lm -ladc -luart -lspi -lcan -lqueue -lstack -ltimer -lheartbeat -lconversions -lpex -ldac lwatchdog
+LIB = -L../../lib -lprintf_flt -lm -ladc -luart -lspi -lcan -lqueue -lstack -ltimer -lheartbeat -lconversions -lpex -ldac
 CFLAGS = -std=gnu99 -Wall -Wl,-u,vfprintf -g -mmcu=atmega32m1 -Os -mcall-prologues
 
 PGMR = stk500

--- a/include/watchdog/watchdog.h
+++ b/include/watchdog/watchdog.h
@@ -1,118 +1,134 @@
-#ifndef WATCHDOG_H
-#define WATCHDOG_H
-
-
-/*
- * watchdog timer
- * look at ch 11.8 of
- * http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8209-8-bit%20AVR%20ATmega16M1-32M1-64M1_Datasheet.pdf
- * for more detailed instruction and register spec
- */
-
-/*
- * 3 MODES OF WATCHDOG TIMER
- * _WD_CONTROL_REG register has 2 field which are WDE and WDIE
- * system reset mode is enabled when WDE bit is set to 1 and
- * interrupt mode is enabled when WDIE bit is set to 1
- *
- * 1. system_reset mode: reset system
- * 2. interrupt mode: call interrupt handler
- * 3. both enabled: call interrupt handler, then automatically switch watchdog timer
- *                  to system reset mode
- *
- * It is often requried to use the third mode (enable both reset and interrupt)
- * to do some necessary operation before reset
- * (for example saving critical parameters)
- */
-
-/*
- * STEPS TO CHANGE WATCHDOG SETUP
- * 1. write logic 1 to WDCE and WDE in _WD_CONTROL_REG
- * 2.
- */
-
-// TODO: check WDP value
-
 #include <stdint.h>
 #include <avr/wdt.h>
 #include <avr/interrupt.h>
-#include <util/delay.h>
 #include <spi/spi.h>
 #include <uart/uart.h>
-#include <uart/log.h>
-//#include "global_header.h"
 
-#define LED_PIN     PB4
-#define LED_DDR     DDRB
-#define LED_PORT    PORTB
-#define TIMEOUT     WDTO_1S
+#define LED_PIN PB4
+#define LED_DDR DDRB
+#define LED_PORT PORTB
 
-#define wdt_clean_up() { MCUSR = 0;	wdt_disable(); }
-//#define WDTCR _WD_CONTROL_REG
+/* Macros written in assembly are used to guarantee that the WDTCSR register is reset within 4 clock cycles of
+    WDCE and WDE being set, as per the data sheet. Functions contain more overhead and take longer to execute,
+    in addition to not running properly with regards to the watchdog timer (even un-optimized)*/
 
-enum wdt_mode {
-    SYS_RESET,
-    INTERRUPTS,
-    BOTH
-};
-enum test_method {
-    PRINTING,
-    LED_OUTPUT
-};
+/* The following constants are pre-defined for use in the watchdog timer in ascending order
+    - WDTO_15MS (0), WDTO_30MS (1), WDTO_60MS (2), WDTO_120MS (3), WDTO_250MS (4),
+      WDTO_500MS (5), WDTO_1S (6), WDTO_2S (7), WDTO_4S (8), WDTO_8S (9)*/
+
+/* wdt_enable(timeout) function is included in the <avr/wdt.h> header file and used for system reset,
+    but for consistency reasons the following three macros are used instead (code is nearly-identical).*/
+
+/* Functions are written in both assembly (more optimal to use) and C (for greater clarity)*/
 
 /*
- * function: init_wdt
- *
- * initialize watchdog timer
- * steps: 1. disalbe interrupts
- *        2. clean up MCU Status Register (MCUSR)
- *           -> MCUSR has flags indicate type of reset that occurred
- *              and therefore requried to be cleaned before initializing wdt
- *           NOTE: currently entire MCUSR is getting wiped out but it might be
- *                 better if only reset WDRF bit, which act as a flag to
- *                 indicate if a system reset occurred due to watchdog timer
- *        3. set WDCE and WDE bit of _WD_CONTROL_REG to 1 which will enable
- *           to write on _WD_CONTROL_REG
- *        4. modify _WD_CONTROL_REG based on input parameters
- *
- *
- * params: wm will decide wich one of three mode watchdog timer will be using
- *         timeout will decide prescaler timeout value which controls how long
- *         the watchdog timer will wait before reseting the system
- *
- * NOTE: currently for testing purpose, the reset frequency will be forced to 1s
- *       regardless of the input parameters value, which should get fixed
- *       fix shouldn't be hard to implement
- */
-void init_wdt(enum wdt_mode wm, uint8_t timeout);
+All functions have same structure:
+  1) Disable interrupts
+  2) Resets watchdog timer
+  3) Sets change bits to enable modification of WDTCSR register
+  4) Configures appropriate timeout and mode
+  5) Re-enable interrupts
+*/
+
+
+/* Triggers interrupts upon timeout */
+ #define WDT_ENABLE_INTERRUPT(timeout)\
+__asm__ __volatile__ ( \
+    "in __tmp_reg__,__SREG__" "\n\t" \
+    "cli" "\n\t" \
+    "wdr" "\n\t" \
+    "sts %0,%1" "\n\t" \
+    "out __SREG__,__tmp_reg__" "\n\t" \
+    "sts %0,%2" "\n\t" \
+    : /* no outputs */  \
+    : "M" (_SFR_MEM_ADDR(WDTCSR)), \
+    "r" (_BV(WDCE) | _BV(WDE)), \
+    "r" ((uint8_t) ((timeout & 0x08 ? _WD_PS3_MASK : 0x00) | \
+        _BV(WDIE) | (timeout & 0x07)) ) \
+    : "r0"  \
+)
+/*#define WDT_ENABLE_INTERRUPT(timeout)\
+    MCUSR = 0;\
+    cli();\
+    wdt_reset();\
+    WDTCSR = _BV(WDCE) | _BV(WDE);\
+    //sets last 3 bits for timeout// \
+    WDTCSR = _BV(WDIE) | (timeout % 8) | ((uint8_t)(timeout/8) << WDP3);\
+    sei();
+*/
+
+/* Sends interrupt on initial timeout, then resets board on second timeout */
+#define WDT_ENABLE_BOTH(timeout)\
+__asm__ __volatile__ ( \
+    "in __tmp_reg__,__SREG__" "\n\t" \
+    "cli" "\n\t" \
+    "wdr" "\n\t" \
+    "sts %0,%1" "\n\t" \
+    "out __SREG__,__tmp_reg__" "\n\t" \
+    "sts %0,%2" "\n\t" \
+    : /* no outputs */  \
+    : "M" (_SFR_MEM_ADDR(WDTCSR)), \
+    "r" (_BV(WDCE) | _BV(WDE)), \
+    "r" ((uint8_t) ((timeout & 0x08 ? _WD_PS3_MASK : 0x00) | \
+        _BV(WDE) | _BV(WDIE) | (timeout & 0x07)) ) \
+    : "r0"\
+)
+
+/*#define WDT_ENABLE_BOTH(timeout)\
+    MCUSR = 0;\
+    cli();\
+    wdt_reset();\
+    WDTCSR = _BV(WDCE) | _BV(WDE);\
+    //sets last 3 bits for timeout//
+    WDTCSR = _BV(WDIE) | _BV(WDE) | (timeout % 8) | ((uint8_t)(timeout/8) << WDP3);\
+    sei();*/
+
+/* Resets board upon timeout */
+#define WDT_ENABLE_SYS_RESET(timeout)\
+__asm__ __volatile__ ( \
+    "in __tmp_reg__,__SREG__" "\n\t" \
+    "cli" "\n\t" \
+    "wdr" "\n\t" \
+    "sts %0,%1" "\n\t" \
+    "out __SREG__,__tmp_reg__" "\n\t" \
+    "sts %0,%2" "\n\t" \
+    : /* no outputs */  \
+    : "M" (_SFR_MEM_ADDR(WDTCSR)), \
+    "r" (_BV(WDCE) | _BV(WDE)), \
+    "r" ((uint8_t) ((timeout & 0x08 ? _WD_PS3_MASK : 0x00) | \
+        _BV(WDE) | (timeout & 0x07)) ) \
+    : "r0"  \
+)
+
+/*#define WDT_ENABLE_SYS_RESET(timeout)\
+    MCUSR = 0;\
+    cli();\
+    wdt_reset();\
+    WDTCSR = _BV(WDCE) | _BV(WDE);\
+    //sets last 3 bits for timeout//
+    WDTCSR = _BV(WDE) | (timeout % 8) | ((uint8_t)(timeout/8) << WDP3);\
+    sei();
+*/
+/* wdt_reset() is included in the <avr/wdt.h> header file and prevents watchdog timer from timing out*/
+
+/* wdt_disable() is included in the <avr/wdt.h> header file and turns off the watchdog timer
+ on newer devices (i.e. 32M1), the WDT_OFF() macro defined below must be used instead*/
+
+/* Turns watchdog timer off*/
+#define WDT_OFF()\
+    cli();\
+    wdt_reset();\
+    MCUSR &= ~(1 << WDRF);\
+    WDTCSR |= (1 << WDCE) | ( 1 << WDE);\
+    WDTCSR = 0x00;\
+    sei();
 
 /*
- * function: disable_wdt
- *
- * disable watchdog timer
- *
- */
-void disable_wdt(void);
-
-/*
- * function: wdt_set_timeout_value
- *
- * change prescaler timeout value which will change the reset frequrency
- * of watchdog timer
- *
- */
-void wdt_set_timeout_value(uint8_t timeout);
-/*
- * function: get_prescaler
- *
- * retrives prescaler timer value which determines how long watchdog timer will
- * wait for wdt_reset to get called before restarting the system
- *
- * mostly used for debugging
- *
- * return: prescaler timer value
- */
-uint32_t get_prescaler(void);
-
-
-#endif
+    void wdt_off(void){
+        cli();
+        wdt_reset();
+        MCUSR &= ~(1 << WDRF);
+        WDTCSR |= (1 << WDCE) | ( 1 << WDE);
+        WDTCSR = 0x00;
+        sei();
+    }*/

--- a/include/watchdog/watchdog.h
+++ b/include/watchdog/watchdog.h
@@ -1,0 +1,118 @@
+#ifndef WATCHDOG_H
+#define WATCHDOG_H
+
+
+/*
+ * watchdog timer
+ * look at ch 11.8 of
+ * http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8209-8-bit%20AVR%20ATmega16M1-32M1-64M1_Datasheet.pdf
+ * for more detailed instruction and register spec
+ */
+
+/*
+ * 3 MODES OF WATCHDOG TIMER
+ * _WD_CONTROL_REG register has 2 field which are WDE and WDIE
+ * system reset mode is enabled when WDE bit is set to 1 and
+ * interrupt mode is enabled when WDIE bit is set to 1
+ *
+ * 1. system_reset mode: reset system
+ * 2. interrupt mode: call interrupt handler
+ * 3. both enabled: call interrupt handler, then automatically switch watchdog timer
+ *                  to system reset mode
+ *
+ * It is often requried to use the third mode (enable both reset and interrupt)
+ * to do some necessary operation before reset
+ * (for example saving critical parameters)
+ */
+
+/*
+ * STEPS TO CHANGE WATCHDOG SETUP
+ * 1. write logic 1 to WDCE and WDE in _WD_CONTROL_REG
+ * 2.
+ */
+
+// TODO: check WDP value
+
+#include <stdint.h>
+#include <avr/wdt.h>
+#include <avr/interrupt.h>
+#include <util/delay.h>
+#include <spi/spi.h>
+#include <uart/uart.h>
+#include <uart/log.h>
+//#include "global_header.h"
+
+#define LED_PIN     PB4
+#define LED_DDR     DDRB
+#define LED_PORT    PORTB
+#define TIMEOUT     WDTO_1S
+
+#define wdt_clean_up() { MCUSR = 0;	wdt_disable(); }
+//#define WDTCR _WD_CONTROL_REG
+
+enum wdt_mode {
+    SYS_RESET,
+    INTERRUPTS,
+    BOTH
+};
+enum test_method {
+    PRINTING,
+    LED_OUTPUT
+};
+
+/*
+ * function: init_wdt
+ *
+ * initialize watchdog timer
+ * steps: 1. disalbe interrupts
+ *        2. clean up MCU Status Register (MCUSR)
+ *           -> MCUSR has flags indicate type of reset that occurred
+ *              and therefore requried to be cleaned before initializing wdt
+ *           NOTE: currently entire MCUSR is getting wiped out but it might be
+ *                 better if only reset WDRF bit, which act as a flag to
+ *                 indicate if a system reset occurred due to watchdog timer
+ *        3. set WDCE and WDE bit of _WD_CONTROL_REG to 1 which will enable
+ *           to write on _WD_CONTROL_REG
+ *        4. modify _WD_CONTROL_REG based on input parameters
+ *
+ *
+ * params: wm will decide wich one of three mode watchdog timer will be using
+ *         timeout will decide prescaler timeout value which controls how long
+ *         the watchdog timer will wait before reseting the system
+ *
+ * NOTE: currently for testing purpose, the reset frequency will be forced to 1s
+ *       regardless of the input parameters value, which should get fixed
+ *       fix shouldn't be hard to implement
+ */
+void init_wdt(enum wdt_mode wm, uint8_t timeout);
+
+/*
+ * function: disable_wdt
+ *
+ * disable watchdog timer
+ *
+ */
+void disable_wdt(void);
+
+/*
+ * function: wdt_set_timeout_value
+ *
+ * change prescaler timeout value which will change the reset frequrency
+ * of watchdog timer
+ *
+ */
+void wdt_set_timeout_value(uint8_t timeout);
+/*
+ * function: get_prescaler
+ *
+ * retrives prescaler timer value which determines how long watchdog timer will
+ * wait for wdt_reset to get called before restarting the system
+ *
+ * mostly used for debugging
+ *
+ * return: prescaler timer value
+ */
+uint32_t get_prescaler(void);
+
+
+#endif

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-SUBDIRS = $(addprefix src/,uart spi can timer queue stack heartbeat test conversions adc pex dac)
+SUBDIRS = $(addprefix src/,uart spi can timer queue stack heartbeat test conversions adc pex dac watchdog)
 EXAMPLES = $(dir $(wildcard examples/*/.))
 
 .PHONY: all $(SUBDIRS) clean examples tests help

--- a/src/watchdog/makefile
+++ b/src/watchdog/makefile
@@ -1,0 +1,2 @@
+LIBNAME = watchdog
+include ../makefile

--- a/src/watchdog/watchdog.c
+++ b/src/watchdog/watchdog.c
@@ -1,0 +1,104 @@
+#include "watchdog.h"
+
+volatile int LED_ON = 0;
+volatile int interrupt_count = 0;
+char* wdt_mode_to_string = {"SYS RESET","INTERRUPT","BOTH"};
+
+
+uint32_t get_prescaler(void){
+    uint8_t fourth = (_WD_CONTROL_REG>>WDP3)%2;
+    uint8_t third = (_WD_CONTROL_REG>>WDP2)%2;
+    uint8_t second = (_WD_CONTROL_REG>>WDP1)%2;
+    uint8_t first = (_WD_CONTROL_REG>>WDP0)%2;
+    uint32_t prescaler = fourth*8+third*4+second*2+first;
+    print("%d",_WD_CONTROL_REG);
+    wdt_reset();
+    return prescaler;
+}
+
+
+void init_wdt(enum wdt_mode wm, uint8_t timeout){
+    cli(); /*disable interrupt*/
+    //wdt_reset();
+    //wdt_clean_up();
+    wdt_disable();
+    print("\n\nSTART\n\n");
+    /*set wdt_mode and timeout*/
+    switch(wm){
+        case SYS_RESET:
+            MCUSR = 0;
+            /*clean _WD_CONTROL_REG values*/
+            _WD_CONTROL_REG = (1<<WDCE) | (1<<WDE);
+            /*set wdt mode and timeout value*/
+            _WD_CONTROL_REG = (1<<WDE) | (1<<WDP2) | (1<<WDP1);
+            print("%d",_WD_CONTROL_REG);
+            break;
+        case INTERRUPTS:
+            MCUSR = 0;
+            /*clean _WD_CONTROL_REG values*/
+            _WD_CONTROL_REG = (1<<WDCE) | (1<<WDE);
+            /*set wdt mode and timeout value*/
+            _WD_CONTROL_REG = (1<<WDIE) | (1<<WDP2) | (1<<WDP1);
+            break;
+        case BOTH:
+            MCUSR = 0;
+            /*clean _WD_CONTROL_REG values*/
+            _WD_CONTROL_REG = (1<<WDCE)|(1<<WDE);
+            /*set wdt mode and timeout value*/
+            _WD_CONTROL_REG = (1<<WDE)| (1<<WDIE) | (1<<WDP2) | (1<<WDP1);
+            print("%d",_WD_CONTROL_REG);
+            break;
+    }
+    wdt_reset();
+    //print("1 %d   %d",_WD_CONTROL_REG,WDE);
+    //wdt_set_timeout_value(timeout);
+    sei(); /*enable interrupt*/
+
+
+    //print("\nWDP%d %d %d %d\n", (_WD_CONTROL_REG>>WDP3) % 2,(_WD_CONTROL_REG>>WDP2) % 2,(_WD_CONTROL_REG>>WDP1) % 2,(_WD_CONTROL_REG>>WDP0) % 2);
+    //print("\nINITIALZING\n");
+    //print("\nWDT MODE IS %s",wdt_mode_to_string[wm]);
+}
+
+void disable_wdt(){
+    print("DISABLE WDT\n");
+    cli();
+    wdt_reset();
+    MCUSR &= ~(1<<WDRF); //TODO: might be 0?
+    _WD_CONTROL_REG = (1<<WDCE)|(1<<WDE);
+    _WD_CONTROL_REG = 0;
+    sei();
+}
+
+void wdt_set_timeout_value(uint8_t timeout){
+    //print("RESETING TIMEOUT VALUE");
+    cli();
+    wdt_reset();
+    uint8_t old_wde = (_WD_CONTROL_REG>>WDE) % 2; // save old WDE value
+    uint8_t old_wdie = (_WD_CONTROL_REG>>WDIE) % 2; // save old WDIE value
+    wdt_reset();
+    // parsing timeout to bits
+    uint8_t wdp_array[3];
+    uint8_t temp = timeout;
+    uint8_t factor = 8;
+    for (int i = 3; i >= 0; i--){
+        wdp_array[i] = (int) temp/factor;
+        temp = temp - wdp_array[i]*factor;
+        factor = factor/2;
+        wdt_reset();
+    }
+    print("dsfs %d %d %d %d\n", wdp_array[3],wdp_array[2],wdp_array[1],wdp_array[0]);
+    wdt_reset();
+    _WD_CONTROL_REG = (1<<WDCE)|(1<<WDE);
+    _WD_CONTROL_REG = (old_wde<<WDE) | (old_wdie<<WDIE) | (wdp_array[3]<<WDP3)
+                         | (wdp_array[2]<<WDP2) | (wdp_array[1]<<WDP1) | (wdp_array[0]<<WDP0);
+    sei();
+}
+
+// watchdog interrupt handler
+ISR(WDT_vect){
+    print("WATCHDOG TIMER INTERRUPT\n");
+    interrupt_count++;
+    print("%dTH INTERRUPT\n", interrupt_count);
+    LED_PORT ^= (1<<LED_PIN);
+}

--- a/src/watchdog/watchdog.c
+++ b/src/watchdog/watchdog.c
@@ -1,104 +1,18 @@
-#include "watchdog.h"
+#include <watchdog/watchdog.h>
+#ifndef F_CPU
+#define F_CPU 8000000UL
+#endif
 
+/*volatile ints can be changed at any time (i.e. during ISR)*/
 volatile int LED_ON = 0;
 volatile int interrupt_count = 0;
-char* wdt_mode_to_string = {"SYS RESET","INTERRUPT","BOTH"};
 
-
-uint32_t get_prescaler(void){
-    uint8_t fourth = (_WD_CONTROL_REG>>WDP3)%2;
-    uint8_t third = (_WD_CONTROL_REG>>WDP2)%2;
-    uint8_t second = (_WD_CONTROL_REG>>WDP1)%2;
-    uint8_t first = (_WD_CONTROL_REG>>WDP0)%2;
-    uint32_t prescaler = fourth*8+third*4+second*2+first;
-    print("%d",_WD_CONTROL_REG);
-    wdt_reset();
-    return prescaler;
-}
-
-
-void init_wdt(enum wdt_mode wm, uint8_t timeout){
-    cli(); /*disable interrupt*/
-    //wdt_reset();
-    //wdt_clean_up();
-    wdt_disable();
-    print("\n\nSTART\n\n");
-    /*set wdt_mode and timeout*/
-    switch(wm){
-        case SYS_RESET:
-            MCUSR = 0;
-            /*clean _WD_CONTROL_REG values*/
-            _WD_CONTROL_REG = (1<<WDCE) | (1<<WDE);
-            /*set wdt mode and timeout value*/
-            _WD_CONTROL_REG = (1<<WDE) | (1<<WDP2) | (1<<WDP1);
-            print("%d",_WD_CONTROL_REG);
-            break;
-        case INTERRUPTS:
-            MCUSR = 0;
-            /*clean _WD_CONTROL_REG values*/
-            _WD_CONTROL_REG = (1<<WDCE) | (1<<WDE);
-            /*set wdt mode and timeout value*/
-            _WD_CONTROL_REG = (1<<WDIE) | (1<<WDP2) | (1<<WDP1);
-            break;
-        case BOTH:
-            MCUSR = 0;
-            /*clean _WD_CONTROL_REG values*/
-            _WD_CONTROL_REG = (1<<WDCE)|(1<<WDE);
-            /*set wdt mode and timeout value*/
-            _WD_CONTROL_REG = (1<<WDE)| (1<<WDIE) | (1<<WDP2) | (1<<WDP1);
-            print("%d",_WD_CONTROL_REG);
-            break;
-    }
-    wdt_reset();
-    //print("1 %d   %d",_WD_CONTROL_REG,WDE);
-    //wdt_set_timeout_value(timeout);
-    sei(); /*enable interrupt*/
-
-
-    //print("\nWDP%d %d %d %d\n", (_WD_CONTROL_REG>>WDP3) % 2,(_WD_CONTROL_REG>>WDP2) % 2,(_WD_CONTROL_REG>>WDP1) % 2,(_WD_CONTROL_REG>>WDP0) % 2);
-    //print("\nINITIALZING\n");
-    //print("\nWDT MODE IS %s",wdt_mode_to_string[wm]);
-}
-
-void disable_wdt(){
-    print("DISABLE WDT\n");
-    cli();
-    wdt_reset();
-    MCUSR &= ~(1<<WDRF); //TODO: might be 0?
-    _WD_CONTROL_REG = (1<<WDCE)|(1<<WDE);
-    _WD_CONTROL_REG = 0;
-    sei();
-}
-
-void wdt_set_timeout_value(uint8_t timeout){
-    //print("RESETING TIMEOUT VALUE");
-    cli();
-    wdt_reset();
-    uint8_t old_wde = (_WD_CONTROL_REG>>WDE) % 2; // save old WDE value
-    uint8_t old_wdie = (_WD_CONTROL_REG>>WDIE) % 2; // save old WDIE value
-    wdt_reset();
-    // parsing timeout to bits
-    uint8_t wdp_array[3];
-    uint8_t temp = timeout;
-    uint8_t factor = 8;
-    for (int i = 3; i >= 0; i--){
-        wdp_array[i] = (int) temp/factor;
-        temp = temp - wdp_array[i]*factor;
-        factor = factor/2;
-        wdt_reset();
-    }
-    print("dsfs %d %d %d %d\n", wdp_array[3],wdp_array[2],wdp_array[1],wdp_array[0]);
-    wdt_reset();
-    _WD_CONTROL_REG = (1<<WDCE)|(1<<WDE);
-    _WD_CONTROL_REG = (old_wde<<WDE) | (old_wdie<<WDIE) | (wdp_array[3]<<WDP3)
-                         | (wdp_array[2]<<WDP2) | (wdp_array[1]<<WDP1) | (wdp_array[0]<<WDP0);
-    sei();
-}
-
-// watchdog interrupt handler
+/* Watchdog interrupt handler: Interrupt triggers when WDIE is set */
 ISR(WDT_vect){
     print("WATCHDOG TIMER INTERRUPT\n");
     interrupt_count++;
     print("%dTH INTERRUPT\n", interrupt_count);
-    LED_PORT ^= (1<<LED_PIN);
+    //Alternates LED_PORT between states (i.e. ISR triggering twice will get back to initial state)
+    LED_PORT ^= (1 << LED_PIN);
+    print("LED_PORT: %d\n", LED_PORT);
 }

--- a/tests/watchdog/main1.c
+++ b/tests/watchdog/main1.c
@@ -1,0 +1,89 @@
+/* This file includes 5 tests to verify the functionality of the watchdog timer.
+    In interrupt-mode, the while loop breaks when an interrupt is triggered (see ISR in watchdog.c).
+    The test is then able to complete, and the time taken to run is verified in the test suite member.
+    NOTE: Times are dependent on the voltage supplied to the 32M1 (see data sheet) and are not exact.
+          Some variation in the time member is normal.
+    Times for the non-interrupt mode are not tested directly due to test harness limitations, but have been
+    previously shown to work in other testing environments (i.e. func_tests). Only the register values for
+    these modes are verified here */
+
+#include <uart/uart.h>
+#include <watchdog/watchdog.h>
+#include <test/test.h>
+
+void interrupt_test(void) {
+    /*Enables interrupt-mode watchdog timer for 1s*/
+    WDT_OFF();
+    WDT_ENABLE_INTERRUPT(WDTO_1S); //wdt_enable_interrupt(WDTO_1S);
+    uint8_t led_port = LED_PORT;
+    while(led_port == LED_PORT){
+      //do nothing (should be changed when WDT goes off)
+    }
+    //verify that interrupt occurs by checking LED_PORT
+    ASSERT_EQ(led_port ^ _BV(LED_PIN), LED_PORT);
+}
+
+void disable_test(void) {
+    /*Disables watchdog timer and tests register values*/
+    WDT_OFF();
+    //assert: wdt disabled, interrupts enabled
+    ASSERT_EQ(WDTCSR, 0);
+    ASSERT_EQ(MCUSR & 0x08, 0x00); //WDRF disabled
+}
+
+void set_2s_timeout(void) {
+    /*Sets timeout to 2s, tests time to exit loop*/
+    WDT_OFF();
+    WDT_ENABLE_INTERRUPT(WDTO_2S);
+    uint8_t led_port = LED_PORT;
+    while(led_port == LED_PORT){
+    //do nothing (should be changed when WDT goes off)
+    }
+    ASSERT_EQ(led_port ^ _BV(LED_PIN), LED_PORT);
+}
+
+void set_250ms_timeout(void) {
+    /*Sets timeout to 250ms, tests time to exit loop*/
+    WDT_OFF();
+    WDT_ENABLE_INTERRUPT(WDTO_250MS);
+    uint8_t led_port = LED_PORT;
+    while(led_port == LED_PORT){
+    //do nothing (should be changed when WDT goes off)
+    }
+    ASSERT_EQ(led_port ^ _BV(LED_PIN), LED_PORT);
+}
+
+void init_test(void){
+    /*Does not test board reset directly due to test harness limitations, but verifies
+    that register values are correct*/
+    WDT_OFF();
+
+    WDT_ENABLE_BOTH(WDTO_1S);
+    ASSERT_EQ(WDTCSR, _BV(WDE) | _BV(WDIE) | _BV(WDP2) | _BV(WDP1));
+    WDT_OFF();
+
+    WDT_ENABLE_SYS_RESET(WDTO_1S);
+    ASSERT_EQ(WDTCSR, _BV(WDE) | _BV(WDP2) | _BV(WDP1));
+    WDT_OFF();
+
+    WDT_ENABLE_INTERRUPT(WDTO_1S);
+    ASSERT_EQ(WDTCSR, _BV(WDIE) | _BV(WDP2) | _BV(WDP1));
+    WDT_OFF();
+}
+
+/* Times are not exact, but are determined through testing. Some variance is normal. */
+test_t t1 = { .name = "Interrupt Mode (1.0s)", .fn = interrupt_test, .time = 1.217 };
+test_t t2 = { .name = "Disable WDT", .fn = disable_test };
+test_t t3 = { .name = "Set 2.0s timeout", .fn = set_2s_timeout, .time = 2.32};
+test_t t4 = { .name = "Set 0.25s timeout", .fn = set_250ms_timeout, .time = 0.373};
+test_t t5 = { .name = "Initialization Test", .fn = init_test};
+
+test_t* suite[5] = { &t1, &t2, &t3, &t4, &t5};
+
+int main(void) {
+    //ensure that the watchdog timer is disabled before running tests
+    WDT_OFF();
+    run_tests(suite, 5);
+    print("TESTS COMPLETE\n");
+    return 0;
+}


### PR DESCRIPTION
The watchdog timer library has been rewritten to use macros instead of functions and has been verified to function as expected. A test harness test suite is also included in this pull request. 
@brunofalmeida 