### PR TITLE
UART library review

### DIFF
--- a/include/uart/uart.h
+++ b/include/uart/uart.h
@@ -10,25 +10,25 @@
 #define F_IO 1000000UL // 1 MHz after CKDIV8
 #define BAUD_RATE 9600UL
 #define BIT_SAMPLES 4UL
-#define PRINT_BUF_SIZE 50
 
-//#define UART_TX PD3
-//#define UART_RX PD4
+// UART TXD is pin PD3
+// UART RXD is pin PD4
 
-// UART
-typedef uint8_t(*global_rx_cb_t)(const uint8_t*, uint8_t);
 
-void get_char(uint8_t*);
-void register_callback(global_rx_cb_t);
-void clear_rx_buffer();
+// UART RX callback function signature
+typedef uint8_t(*uart_rx_cb_t)(const uint8_t*, uint8_t);
 
+// UART RX/TX (from uart.c)
 void put_char(uint8_t);
-void init_uart();
-void send_uart(const uint8_t*, int);
+void get_char(uint8_t*);
+void init_uart(void);
+void send_uart(const uint8_t*, uint8_t);
+void set_uart_rx_cb(uart_rx_cb_t);
+void register_callback(uart_rx_cb_t);
+void clear_rx_buffer(void);
 
-// Printing
-int print(char*, ...);
-int uprintf(char*, ...);
+// Printing (from log.c)
+int16_t print(char*, ...);
 void print_bytes(uint8_t*, uint8_t);
 
 #endif // UART_H

--- a/src/uart/log.c
+++ b/src/uart/log.c
@@ -1,30 +1,42 @@
+/*
+UART library logging
+Functions for using variable arguments and format specifiers to print messages.
+*/
+
 #include <uart/uart.h>
 
+// Character buffer for formatted print messages
+#define PRINT_BUF_SIZE 50
 uint8_t print_buf[PRINT_BUF_SIZE];
 
-// UART must be initialized before calling print
-inline int print(char* str, ...) {
-    va_list ptr;
-    va_start(ptr, str);
+/*
+Prints a message by sending UART.
+Uses same format specifiers as the standard C printf() function
+(http://www.cplusplus.com/reference/cstdio/printf/?kw=printf)
 
-    int ret = vsprintf((char*)print_buf, str, ptr);
-    va_end(ptr);
+Note: UART must be initialized (with init_uart()) before calling print
+Note: Floating point output (with %f) is not available by default, must add
+      -lprintf_flt flag to linking command
 
-    send_uart(print_buf, strlen((char*)print_buf));
+str - Format string for the message
+variable arguments - To be substituted for format specifiers
+*/
+inline int16_t print(char* str, ...) {
+    va_list args;
+    va_start(args, str);
+
+    int16_t ret = vsprintf((char*) print_buf, str, args);
+    va_end(args);
+
+    send_uart(print_buf, strlen((char*) print_buf));
     return ret;
 }
 
-inline int uprintf(char* str, ...) {
-    va_list ptr;
-    va_start(ptr, str);
-
-    int ret = vsprintf((char*)print_buf, str, ptr);
-    va_end(ptr);
-
-    send_uart(print_buf, strlen((char*)print_buf));
-    return ret;
-}
-
+/*
+Prints an array of bytes in hex format on the same line.
+data - pointer to beginning of array
+len - number of bytes in array
+*/
 void print_bytes(uint8_t* data, uint8_t len) {
     for (uint8_t i = 0; i < len; i++) {
         print("0x%.2x ", data[i]);

--- a/src/uart/uart.c
+++ b/src/uart/uart.c
@@ -1,37 +1,59 @@
+/*
+UART (TX and RX) library.
+
+32M1/64M1 datasheet: https://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8209-8-bit%20AVR%20ATmega16M1-32M1-64M1_Datasheet.pdf
+
+TODO - maybe implement functions to get the buffer count and extract
+       characters without an interrupt callback?
+*/
+
 #include <uart/uart.h>
 #include <string.h>
 
+// Maximum number of characters the UART RX buffer can store
 #define MAX_RX_BUF_SIZE 50
 
+// Buffer of received characters
+// TODO - should this be volatile?
 uint8_t uart_rx_buf[MAX_RX_BUF_SIZE];
-volatile uint8_t uart_rx_buf_counter;
+// Number of valid characters in buffer (starting at index 0)
+volatile uint8_t uart_rx_buf_count;
 
-// default rx callback
-uint8_t _nop(const uint8_t* c, uint8_t len) { return 0; }
-global_rx_cb_t global_rx_cb = _nop;
+// default rx callback (no operation)
+uint8_t _nop(const uint8_t* c, uint8_t len) {
+    return 0;
+}
+// Global RX callback function
+uart_rx_cb_t global_rx_cb = _nop;
 
+
+// Sends one character over UART (TX)
 void put_char(uint8_t c) {
-    uint16_t TIMEOUT = 65535;
-    while ((LINSIR & _BV(LBUSY)) && TIMEOUT--);
+    uint16_t timeout = UINT16_MAX;
+    while ((LINSIR & _BV(LBUSY)) && timeout--);
     LINDAT = c;
 }
 
-// Maybe change to uint8_t get_char(uint8_t*) and write value directly?
+// Gets (receives) one character from UART (RX) and sets the value of `c`
+// TODO - Maybe change to uint8_t get_char(uint8_t*) and write value directly?
 // Frees up ret val for error handling
 void get_char(uint8_t* c) {
-    int TIMEOUT = 65535;
-    while ((LINSIR & _BV(LBUSY)) && TIMEOUT--);
+    uint16_t timeout = UINT16_MAX;
+    while ((LINSIR & _BV(LBUSY)) && timeout--);
     *c = LINDAT;
 }
 
-void init_uart() {
+// Initializes the UART library
+void init_uart(void) {
     LINCR = _BV(LSWRES); // reset UART
 
-    int16_t LDIV = (F_IO/(BAUD_RATE*BIT_SAMPLES)) - 1;
+    int16_t LDIV = (F_IO / (BAUD_RATE * BIT_SAMPLES)) - 1;
     // this number is not necessarily integer; if the number is too far from
     // being an integer, too much error will accumulate and UART will output
     // garbage
 
+
+    // TODO - should these two lines be atomic?
     LINBRRH = (uint8_t) LDIV >> 8;
     LINBRRL = (uint8_t) LDIV;
 
@@ -49,40 +71,64 @@ void init_uart() {
     // reset RX buffer and counter
 }
 
-void send_uart(const uint8_t* msg, int len) {
+/*
+Sends a sequence of characters over UART.
+msg - pointer to start of array
+len - number of characters
+*/
+void send_uart(const uint8_t* msg, uint8_t len) {
     for (uint8_t i = 0; i < len; i++) {
         put_char(msg[i]);
     }
 }
 
-void register_callback(global_rx_cb_t cb) {
+/*
+Sets the callback function that will be called when UART receives data.
+
+The function must have the following signature:
+uint8_t func(const uint8_t* data, uint8_t len);
+
+The UART library will pass a pointer to the array (data) and the number of characters (len).
+The function can process the characters however it wants and must return the
+number of characters it has "processed", which will then be removed from the uart_rx_buf.
+*/
+void set_uart_rx_cb(uart_rx_cb_t cb) {
     global_rx_cb = cb;
 }
 
-void clear_rx_buffer() {
-    uart_rx_buf_counter = 0;
+// TODO - remove this function
+// Keeping it for now so code doesn't break
+void register_callback(uart_rx_cb_t cb) {
+    set_uart_rx_cb(cb);
+}
+
+// Clears the RX buffer (sets all values in the arraay to 0 and sets counter to 0)
+void clear_rx_buffer(void) {
+    uart_rx_buf_count = 0;
     for (uint8_t i = 0; i < MAX_RX_BUF_SIZE; i++) {
         uart_rx_buf[i] = 0;
     }
 }
 
+// Interrupt handler that will be called when we receive a character over UART
 ISR(LIN_TC_vect) {
     if (LINSIR & _BV(LRXOK)) {
         static uint8_t c;
         get_char(&c);
 
-        uart_rx_buf[uart_rx_buf_counter] = c;
-        uart_rx_buf_counter += 1;
+        uart_rx_buf[uart_rx_buf_count] = c;
+        uart_rx_buf_count += 1;
 
-        uint8_t rb = global_rx_cb(uart_rx_buf, uart_rx_buf_counter);
+        uint8_t read_bytes = global_rx_cb(uart_rx_buf, uart_rx_buf_count);
 
         // shift everything leftward by the number of bytes read, if any
-        if (rb > 0) {
-            memmove(uart_rx_buf, uart_rx_buf + rb, 50 - rb);
-            uart_rx_buf_counter -= rb;
+        if (read_bytes > 0) {
+            memmove(uart_rx_buf, uart_rx_buf + read_bytes, MAX_RX_BUF_SIZE - read_bytes);
+            uart_rx_buf_count -= read_bytes;
         }
 
-        if (uart_rx_buf_counter == MAX_RX_BUF_SIZE) {
+        // If the buffer is full, clear it
+        if (uart_rx_buf_count >= MAX_RX_BUF_SIZE) {
             clear_rx_buffer();
         }
 


### PR DESCRIPTION
- Cleanup and documentation
- Fixed use of timeouts and constants
- Renamed `register_callback()` to `set_uart_rx_cb()`, but kept `register_callback()` for now to not break existing code (will be removed later)
