### PR TITLE
UART fixes

### DIFF
--- a/examples/uart_echo/uart_echo.c
+++ b/examples/uart_echo/uart_echo.c
@@ -10,6 +10,12 @@
 // of any string is consistently dropped. When sending the characters with
 // a 3ms delay, this effect disappears.
 
+// UPDATE (2018-12-19): By changing the LDIV formula in init_uart() from
+// (... - 1) to (... - 2), this effect occurs for every 17th or 18th character instead
+// of every 11th. This a temporary improvement, but still needs to be
+// investigated. Perhaps the UART RX and TX are conflicting and received data is
+// being lost in the buffer?
+
 uint8_t echo(const uint8_t* buf, uint8_t len) {
     for (uint8_t i = 0; i < len; i++) {
         put_char(buf[i]);
@@ -20,7 +26,7 @@ uint8_t echo(const uint8_t* buf, uint8_t len) {
 
 int main(void) {
     init_uart();
-    register_callback(echo);
+    set_uart_rx_cb(echo);
 
     while (1) {};
 }

--- a/harness_tests/uart/main1.c
+++ b/harness_tests/uart/main1.c
@@ -23,7 +23,8 @@ void get_char_test(void){
 void init_uart_test(void){
     init_uart();
     ASSERT_EQ(LINBRRH, 0);
-    ASSERT_EQ(LINBRRL, 25);
+    // TODO - this should be 25 according to the correct LDIV formula (p. 282)
+    ASSERT_EQ(LINBRRL, 24);
     ASSERT_EQ(LINBTR, 32);
     ASSERT_EQ(LINCR, _BV(LENA) | _BV(LCMD2) | _BV(LCMD1) | _BV(LCMD0));
     ASSERT_EQ(LINENIR, _BV(LENRXOK));

--- a/include/uart/uart.h
+++ b/include/uart/uart.h
@@ -8,12 +8,13 @@
 #include <stdio.h>
 
 // With the current fuse settings (FF D7 FF), the CKDIV8 bit is not programmed.
-// It seems like there is no clock divison for clk_io (8 MHz).
+// It seems like there is no clock divison for clk_io (therefore 8 MHz).
 // TODO - should it be 1 MHz after CKDIV8?
 // clk_io frequency (p. 17, 48, 54, 143, 280, 282, 298)
 #define F_IO 8000000UL
 
 // Baud rate (number of samples per second)
+// This needs to match the baud rate for the transceiver/CoolTerm
 // p. 282, 298
 #define BAUD_RATE 9600UL
 

--- a/include/uart/uart.h
+++ b/include/uart/uart.h
@@ -7,9 +7,18 @@
 #include <stdarg.h>
 #include <stdio.h>
 
-#define F_IO 1000000UL // 1 MHz after CKDIV8
+// With the current fuse settings (FF D7 FF), the CKDIV8 bit is not programmed.
+// It seems like there is no clock divison for clk_io (8 MHz).
+// TODO - should it be 1 MHz after CKDIV8?
+// clk_io frequency (p. 17, 48, 54, 143, 280, 282, 298)
+#define F_IO 8000000UL
+
+// Baud rate (number of samples per second)
+// p. 282, 298
 #define BAUD_RATE 9600UL
-#define BIT_SAMPLES 4UL
+
+// LBT[5:0] value in LINBTR register (p. 283, 289, 297)
+#define BIT_SAMPLES 32UL
 
 // UART TXD is pin PD3
 // UART RXD is pin PD4
@@ -24,7 +33,6 @@ void get_char(uint8_t*);
 void init_uart(void);
 void send_uart(const uint8_t*, uint8_t);
 void set_uart_rx_cb(uart_rx_cb_t);
-void register_callback(uart_rx_cb_t);
 void clear_rx_buffer(void);
 
 // Printing (from log.c)

--- a/src/test/test.c
+++ b/src/test/test.c
@@ -56,7 +56,7 @@ uint8_t test_count_cb(const uint8_t* data, uint8_t len) {
 
     if (flag == 1) {
         print("%d\r\n", test_num);
-        register_callback(test_start_cb);
+        set_uart_rx_cb(test_start_cb);
     }
 
     clear_rx_buffer();
@@ -67,7 +67,7 @@ void run_tests(test_t** suite, uint8_t len) {
     init_uart();
     test_suite = suite;
     test_num = len;
-    register_callback(test_count_cb);
+    set_uart_rx_cb(test_count_cb);
 
     __attribute__((unused)) uint8_t curr_cpy;
     // GCC magic to make the compiler shut up
@@ -113,6 +113,6 @@ uint8_t slave_kill_cb(const uint8_t* data, uint8_t len) {
 void run_slave() {
     init_uart();
     curr_test = -1;
-    register_callback(slave_kill_cb);
+    set_uart_rx_cb(slave_kill_cb);
     while (curr_test != 0) {};
 }

--- a/src/uart/uart.c
+++ b/src/uart/uart.c
@@ -47,16 +47,21 @@ void get_char(uint8_t* c) {
 void init_uart(void) {
     LINCR = _BV(LSWRES); // reset UART
 
-    int16_t LDIV = (F_IO / (BAUD_RATE * BIT_SAMPLES)) - 1;
+    // TODO - 2?
+    // Scaling of clk_io frequency
+    // Value to assign to 16-bit LINBRR register (p. 298)
+    // Calculated from formula on p.282
+    int16_t LDIV = (F_IO / (BAUD_RATE * BIT_SAMPLES)) - 2;
     // this number is not necessarily integer; if the number is too far from
     // being an integer, too much error will accumulate and UART will output
     // garbage
 
-
+    // Set LDIV (clock scaling) value to LINBRR
     // TODO - should these two lines be atomic?
-    LINBRRH = (uint8_t) LDIV >> 8;
+    LINBRRH = (uint8_t) (LDIV >> 8);
     LINBRRL = (uint8_t) LDIV;
 
+    // Set number of samples per bit (p. 297)
     LINBTR = BIT_SAMPLES;
 
     LINCR = _BV(LENA) | _BV(LCMD2) | _BV(LCMD1) | _BV(LCMD0);
@@ -94,12 +99,6 @@ number of characters it has "processed", which will then be removed from the uar
 */
 void set_uart_rx_cb(uart_rx_cb_t cb) {
     global_rx_cb = cb;
-}
-
-// TODO - remove this function
-// Keeping it for now so code doesn't break
-void register_callback(uart_rx_cb_t cb) {
-    set_uart_rx_cb(cb);
 }
 
 // Clears the RX buffer (sets all values in the arraay to 0 and sets counter to 0)

--- a/src/uart/uart.c
+++ b/src/uart/uart.c
@@ -47,21 +47,24 @@ void get_char(uint8_t* c) {
 void init_uart(void) {
     LINCR = _BV(LSWRES); // reset UART
 
-    // TODO - 2?
     // Scaling of clk_io frequency
     // Value to assign to 16-bit LINBRR register (p. 298)
     // Calculated from formula on p.282
+    // TODO - this should actually be (... - 1) from the datsheet, but using
+    // (... - 2) gives less character errors - find a solution
     int16_t LDIV = (F_IO / (BAUD_RATE * BIT_SAMPLES)) - 2;
     // this number is not necessarily integer; if the number is too far from
     // being an integer, too much error will accumulate and UART will output
     // garbage
 
-    // Set LDIV (clock scaling) value to LINBRR
+    // Set LINBRR 16-bit register to LDIV (clock scaling) value
     // TODO - should these two lines be atomic?
     LINBRRH = (uint8_t) (LDIV >> 8);
     LINBRRL = (uint8_t) LDIV;
 
     // Set number of samples per bit (p. 297)
+    // TODO - is the register not readable/writable?
+    // the default value is 32, so this might not actually be changing anything
     LINBTR = BIT_SAMPLES;
 
     LINCR = _BV(LENA) | _BV(LCMD2) | _BV(LCMD1) | _BV(LCMD0);


### PR DESCRIPTION
- Adjusted the LDIV calculation formula to reduce RX character error frequency (used to be once every 11 bits, now is once every 17-18 bits)
- Removed `register_callback()` function
- Added and updated documentation
