### PR TITLE
Thermistor conversions

### DIFF
--- a/include/conversions/conversions.h
+++ b/include/conversions/conversions.h
@@ -21,13 +21,13 @@
 #define OPTICAL_ADC_V_REF   2.5 // reference voltage (in V)
 #define OPTICAL_ADC_N       24  // number of bits in raw data
 
-#define THERMIS_V_REF     2.5
-#define THERMIS_R_REF 10.0 // when referencing table in thermistors.c, values are in kilo Ohmns
+#define THERM_V_REF 2.5
+// when referencing table in thermistors.c, values are in kilo Ohmns
+// Reference in kohm
+#define THERM_R_REF 10.0
 
-// Resistances are stored in kilo-ohms
-// PROGMEM instructs the compiler to store these values in flash memory
 extern const float THERM_RES[];
-extern const int THERM_TEMP[];
+extern const int8_t THERM_TEMP[];
 #define THERM_LUT_COUNT 34
 
 
@@ -43,9 +43,9 @@ double pres_raw_data_to_pressure(uint32_t raw_data);
 
 double optical_adc_raw_data_to_voltage(uint32_t raw_data, uint8_t gain);
 
-double thermis_resistance_to_temp(double resistance);
-double thermis_temp_to_resistance(double temp);
-double thermis_resistance_to_voltage(double resistance);
-double thermis_voltage_to_resistance(double voltage);
+double therm_res_to_temp(double resistance);
+double therm_temp_to_res(double temp);
+double therm_res_to_vol(double resistance);
+double therm_vol_to_res(double voltage);
 
 #endif

--- a/include/conversions/conversions.h
+++ b/include/conversions/conversions.h
@@ -3,6 +3,8 @@
 
 #include <stdint.h>
 
+#include <avr/pgmspace.h>
+
 // Reference voltage
 #define ADC_V_REF 5.0
 
@@ -19,6 +21,15 @@
 #define OPTICAL_ADC_V_REF   2.5 // reference voltage (in V)
 #define OPTICAL_ADC_N       24  // number of bits in raw data
 
+#define THERMIS_V_REF     2.5
+#define THERMIS_R_REF 10.0 // when referencing table in thermistors.c, values are in kilo Ohmns
+
+// Resistances are stored in kilo-ohms
+// PROGMEM instructs the compiler to store these values in flash memory
+extern const float THERM_RES[];
+extern const int THERM_TEMP[];
+#define THERM_LUT_COUNT 34
+
 
 double adc_raw_data_to_raw_voltage(uint16_t raw_data);
 double adc_eps_raw_voltage_to_voltage(double raw_voltage);
@@ -31,5 +42,10 @@ double hum_raw_data_to_humidity(uint16_t raw_data);
 double pres_raw_data_to_pressure(uint32_t raw_data);
 
 double optical_adc_raw_data_to_voltage(uint32_t raw_data, uint8_t gain);
+
+double thermis_resistance_to_temp(double resistance);
+double thermis_temp_to_resistance(double temp);
+double thermis_resistance_to_voltage(double resistance);
+double thermis_voltage_to_resistance(double voltage);
 
 #endif

--- a/include/conversions/conversions.h
+++ b/include/conversions/conversions.h
@@ -27,7 +27,7 @@
 #define THERM_R_REF 10.0
 
 extern const float THERM_RES[];
-extern const int8_t THERM_TEMP[];
+extern const int16_t THERM_TEMP[];
 #define THERM_LUT_COUNT 34
 
 

--- a/manual_tests/conversions_test/conversions_test.c
+++ b/manual_tests/conversions_test/conversions_test.c
@@ -1,0 +1,27 @@
+/*
+Test the data conversion functions in the conversions library.
+*/
+
+#include <conversions/conversions.h>
+#include <uart/uart.h>
+
+// thermistor conversions
+void test_therm() {
+    print("Thermistors:\n");
+
+    print("therm_res_to_temp: 18k -> %.3f C\n", therm_res_to_temp(18.0));
+    print("therm_temp_to_res: 31.2 C -> %.3fk\n", therm_temp_to_res(31.2));
+    print("therm_res_to_vol: 112.9k -> %.3f V\n", therm_res_to_vol(112.9));
+    print("therm_vol_to_res: 2.3 V -> %.3fk\n", therm_vol_to_res(2.3));
+}
+
+
+int main(void) {
+    init_uart();
+
+    print("\n\nStarting test\n\n");
+    test_therm();
+    print("\nDone test\n");
+
+    while (1) {}
+}

--- a/manual_tests/conversions_test/makefile
+++ b/manual_tests/conversions_test/makefile
@@ -1,0 +1,2 @@
+PROG = conversions_test
+include ../makefile

--- a/src/conversions/conversions.c
+++ b/src/conversions/conversions.c
@@ -133,3 +133,97 @@ double optical_adc_raw_data_to_voltage(uint32_t raw_data, uint8_t gain) {
     double denom = (1UL << OPTICAL_ADC_N) * ((double) gain);
     return num / denom;
 }
+
+
+
+
+/*
+Thermistor conversions
+
+For NTC Thermistor 10k 0603 (1608 Metric) Part # NCU18XH103F60RB
+Digikey link: https://www.digikey.ca/product-detail/en/murata-electronics-north-america/NCU18XH103F60RB/490-16279-1-ND/7363262
+Datasheet (page 13. Part # NCU__XH103):
+https://www.murata.com/~/media/webrenewal/support/library/catalog/products/thermistor/r03e.ashx?la=en-us
+Datasheet (NCU18XH103F60RB): https://www.murata.com/en-us/api/pdfdownloadapi?cate=luNTCforTempeSenso&partno=NCU18XH103F60RB
+
+TODO - create test to verify PROGMEM values
+TODO - confirm thermistor part number
+*/
+
+// Lookup table from manufacturer datasheet (pg 13)
+// Resistances are stored in kilo-ohms
+// PROGMEM instructs the compiler to store these values in flash memory
+const float THERM_RES[THERM_LUT_COUNT] PROGMEM = {
+    195.652,    148.171,    113.347,    87.559,     68.237,
+    53.650,     42.506,     33.892,     27.219,     22.021,
+    17.926,     14.674,     12.081,     10.000,     8.315,
+    6.948,      5.834,      4.917,      4.161,      3.535,
+    3.014,      2.586,      2.228,      1.925,      1.669,
+    1.452,      1.268,      1.110,      0.974,      0.858,
+    0.758,      0.672,      0.596,      0.531
+};
+
+// Temperatures in C
+const int THERM_TEMP[THERM_LUT_COUNT] PROGMEM = {
+    -40,        -35,        -30,        -25,        -20,
+    -15,        -10,        -5,         0,          5,
+    10,         15,         20,         25,         30,
+    35,         40,         45,         50,         55,
+    60,         65,         70,         75,         80,
+    85,         90,         95,         100,        105,
+    110,        115,        120,        125
+};
+
+
+// Convert the measured thermistor resistance to temperature
+double thermis_resistance_to_temp(double resistance){
+    for (uint8_t i = 0; i < THERM_LUT_COUNT - 1; i++){
+        double resistance_next = pgm_read_float(&THERM_RES[i + 1]);
+
+        if ((resistance - resistance_next) >= 0){
+            double resistance_prev = pgm_read_float(&THERM_RES[i]);
+            int16_t temp_next = pgm_read_word(&THERM_TEMP[i + 1]);
+            int16_t temp_prev = pgm_read_word(&THERM_TEMP[i]);
+
+            double diff = resistance - resistance_prev;  //should be negative
+            double slope = ((double) (temp_next - temp_prev)) / (resistance_next - resistance_prev);
+            return temp_prev + (diff * slope);
+        }
+    }
+
+    // TODO - this shouldn't happen
+    return 0.0;
+}
+
+// Convert the thermistor temperature to resistance
+double thermis_temp_to_resistance(double temp) {
+    for (uint8_t i = 0; i < THERM_LUT_COUNT - 1; i++){
+        int16_t temp_next = pgm_read_word(&THERM_TEMP[i + 1]);
+
+        if ((temp - temp_next) <= 0){
+            int16_t temp_prev = pgm_read_word(&THERM_TEMP[i]);
+            double resistance_next = pgm_read_float(&THERM_RES[i + 1]);
+            double resistance_prev = pgm_read_float(&THERM_RES[i]);
+
+            double diff = temp - temp_prev;  //should be negative
+            double slope = (resistance_next - resistance_prev) / ((double) (temp_next - temp_prev));
+            return resistance_prev + (diff * slope);
+        }
+    }
+
+    // TODO - this shouldn't happen
+    return 0.0;
+}
+
+// Get the voltage at the point between the thermistor and the constant 10k resistor
+// (10k connected to ground)
+// See: https://www.allaboutcircuits.com/projects/measuring-temperature-with-an-ntc-thermistor/
+double thermis_resistance_to_voltage(double resistance) {
+    return THERMIS_V_REF * THERMIS_R_REF / (resistance + THERMIS_R_REF);
+}
+
+// Get the resistance of the thermistor given the voltage
+// For equation, see: https://www.allaboutcircuits.com/projects/measuring-temperature-with-an-ntc-thermistor/
+double thermis_voltage_to_resistance(double voltage) {
+    return THERMIS_R_REF * (THERMIS_V_REF / voltage - 1);
+}

--- a/src/conversions/conversions.c
+++ b/src/conversions/conversions.c
@@ -164,7 +164,7 @@ const float THERM_RES[THERM_LUT_COUNT] PROGMEM = {
 };
 
 // Temperatures in C
-const int THERM_TEMP[THERM_LUT_COUNT] PROGMEM = {
+const int8_t THERM_TEMP[THERM_LUT_COUNT] PROGMEM = {
     -40,        -35,        -30,        -25,        -20,
     -15,        -10,        -5,         0,          5,
     10,         15,         20,         25,         30,
@@ -176,7 +176,7 @@ const int THERM_TEMP[THERM_LUT_COUNT] PROGMEM = {
 
 
 // Convert the measured thermistor resistance to temperature
-double thermis_resistance_to_temp(double resistance){
+double therm_res_to_temp(double resistance){
     for (uint8_t i = 0; i < THERM_LUT_COUNT - 1; i++){
         double resistance_next = pgm_read_float(&THERM_RES[i + 1]);
 
@@ -196,7 +196,7 @@ double thermis_resistance_to_temp(double resistance){
 }
 
 // Convert the thermistor temperature to resistance
-double thermis_temp_to_resistance(double temp) {
+double therm_temp_to_res(double temp) {
     for (uint8_t i = 0; i < THERM_LUT_COUNT - 1; i++){
         int16_t temp_next = pgm_read_word(&THERM_TEMP[i + 1]);
 
@@ -215,15 +215,15 @@ double thermis_temp_to_resistance(double temp) {
     return 0.0;
 }
 
-// Get the voltage at the point between the thermistor and the constant 10k resistor
+// Using the thermistor resistance, get the voltage at the point between the thermistor and the constant 10k resistor
 // (10k connected to ground)
 // See: https://www.allaboutcircuits.com/projects/measuring-temperature-with-an-ntc-thermistor/
-double thermis_resistance_to_voltage(double resistance) {
-    return THERMIS_V_REF * THERMIS_R_REF / (resistance + THERMIS_R_REF);
+double therm_res_to_vol(double resistance) {
+    return THERM_V_REF * THERM_R_REF / (resistance + THERM_R_REF);
 }
 
 // Get the resistance of the thermistor given the voltage
 // For equation, see: https://www.allaboutcircuits.com/projects/measuring-temperature-with-an-ntc-thermistor/
-double thermis_voltage_to_resistance(double voltage) {
-    return THERMIS_R_REF * (THERMIS_V_REF / voltage - 1);
+double therm_vol_to_res(double voltage) {
+    return THERM_R_REF * (THERM_V_REF / voltage - 1);
 }


### PR DESCRIPTION
Moved the thermistor data conversion code from `pay` because it needs to also be accessed by OBC for integration.

- `thermistors.c` -> `conversions.c`
- `thermistors.h` -> `conversions.h`
- New `manual_tests/conversions_test`
