### PR TITLE
Atomic queue operations

### DIFF
--- a/harness_tests/queue/main1.c
+++ b/harness_tests/queue/main1.c
@@ -22,6 +22,7 @@ void init_queue_test() {
     // Verify that the queue is initialized correctly
     ASSERT_EQ(queue.head, 0);
     ASSERT_EQ(queue.tail, 0);
+    ASSERT_EQ(queue_size(&queue), 0);
 
     // Verify that the queue is empty
     for (uint8_t i = 0; i < MAX_QUEUE_SIZE; i++) {
@@ -38,6 +39,7 @@ void enqueue_simple() {
 
     ASSERT_EQ(queue.head, 0);
     ASSERT_EQ(queue.tail, 1);
+    ASSERT_EQ(queue_size(&queue), 1);
 
     for (uint8_t j = 0; j < QUEUE_DATA_SIZE; j++) {
         ASSERT_EQ(queue.content[0][j], r[j]);
@@ -48,6 +50,7 @@ void enqueue_simple() {
 
     ASSERT_EQ(queue.head, 0);
     ASSERT_EQ(queue.tail, 2);
+    ASSERT_EQ(queue_size(&queue), 2);
 
     for (uint8_t j = 0; j < QUEUE_DATA_SIZE; j++) {
         ASSERT_EQ(queue.content[1][j], s[j]);
@@ -63,6 +66,7 @@ void peek_queue_simple() {
 
     ASSERT_EQ(queue.head, 0);
     ASSERT_EQ(queue.tail, 2);
+    ASSERT_EQ(queue_size(&queue), 2);
 
     for (uint8_t j = 0; j < QUEUE_DATA_SIZE; j++) {
         ASSERT_EQ(data[j], r[j]);
@@ -82,6 +86,7 @@ void dequeue_simple() {
 
     ASSERT_EQ(queue.head, 1);
     ASSERT_EQ(queue.tail, 2);
+    ASSERT_EQ(queue_size(&queue), 1);
 
     for (uint8_t j = 0; j < QUEUE_DATA_SIZE; j++) {
         ASSERT_EQ(data[j], r[j]);
@@ -96,6 +101,7 @@ void dequeue_simple() {
 
     ASSERT_EQ(queue.head, 2);
     ASSERT_EQ(queue.tail, 2);
+    ASSERT_EQ(queue_size(&queue), 0);
 
     for (uint8_t j = 0; j < QUEUE_DATA_SIZE; j++) {
         ASSERT_EQ(data[j], s[j]);
@@ -165,12 +171,14 @@ void mixed_test() {
 
     ASSERT_EQ(queue.head, MAX_QUEUE_SIZE);
     ASSERT_EQ(queue.tail, MAX_QUEUE_SIZE);
+    ASSERT_EQ(queue_size(&queue), 0);
 
     succ = enqueue(&queue, r);
     ASSERT_TRUE(succ);
 
     ASSERT_EQ(queue.head, 0);
     ASSERT_EQ(queue.tail, 1);
+    ASSERT_EQ(queue_size(&queue), 1);
 }
 
 test_t t1 = { .name = "init_queue", .fn = init_queue_test };

--- a/include/queue/queue.h
+++ b/include/queue/queue.h
@@ -21,6 +21,7 @@ typedef struct {
 // NOTE: tail - head is always equal to the queue's size
 
 void init_queue(queue_t* queue);
+uint8_t queue_size(queue_t* queue);
 uint8_t queue_full(queue_t* queue);
 uint8_t queue_empty(queue_t* queue);
 void shift_queue_left(queue_t* queue);

--- a/include/queue/queue.h
+++ b/include/queue/queue.h
@@ -4,6 +4,8 @@
 #include <stdint.h>
 #include <stdlib.h> // for NULL
 
+#include <util/atomic.h>
+
 // Maximum number of elements each queue can store
 #define MAX_QUEUE_SIZE 5
 // Number of bytes per element

--- a/src/queue/queue.c
+++ b/src/queue/queue.c
@@ -31,13 +31,21 @@ void init_queue(queue_t* queue) {
 }
 
 /*
+queue - queue to get the size of
+Returns - the size of the queue (number of 8-byte elements)
+*/
+uint8_t queue_size(queue_t* queue) {
+    return (queue->tail - queue->head);
+}
+
+/*
 Checks whether the queue is full
 
 @param queue_t* queue - queue to check
 @return 1 if the queue has reached maximum capacity, 0 otherwise
 */
 uint8_t queue_full(queue_t* queue) {
-    return ((queue->tail - queue->head) == MAX_QUEUE_SIZE);
+    return (queue_size(queue) == MAX_QUEUE_SIZE);
 }
 
 /*
@@ -47,7 +55,7 @@ Checks whether the queue is empty
 @return 1 if there are no elements in the queue, 0 otherwise
 */
 uint8_t queue_empty(queue_t* queue) {
-    return ((queue->tail - queue->head) == 0);
+    return (queue_size(queue) == 0);
 }
 
 /*
@@ -58,7 +66,7 @@ Shifts all the elements in queue left (to start at index 0)
 void shift_queue_left(queue_t* queue) {
     for (uint8_t i = queue->head; i < queue->tail; i++) {
         for (uint8_t j = 0; j < QUEUE_DATA_SIZE; j++) {
-            queue->content[i - (queue->head)][j] = queue->content[i][j];
+            queue->content[i - queue->head][j] = queue->content[i][j];
             queue->content[i][j] = 0x00;
         }
     }
@@ -83,7 +91,7 @@ uint8_t enqueue(queue_t* queue, const uint8_t* data) {
         }
         uint8_t index = queue->tail;
         for (uint8_t i = 0; i < QUEUE_DATA_SIZE; i++) {
-            (queue->content)[index][i] = data[i];
+            queue->content[index][i] = data[i];
         }
         queue->tail += 1;
         return 1;

--- a/src/queue/queue.c
+++ b/src/queue/queue.c
@@ -11,6 +11,19 @@
     Use-cases (examples):
     - Data that can be reprsented under the FIFO principle
     - Storing data that is asynchronously transferred.
+
+    Need to use atomic blocks (which temporarily prevent interrupts) because
+    queue operations must complete without interference. For example, say we are
+    in the middle of dequeue (copying array contents) when we receive an
+    interrupt that adds a new command (calls enqueue). This will modify
+    head/tail, making the dequeue command fail because it is referring to a
+    different index in the array.
+
+    The compiler seems not to properly recognize return statements inside the
+    atomic blocks. It gives the warning
+    "control reaches end of non-void function [-Wreturn-type]". To silence this,
+    just put `return 0` outside the atomic block where necessary. The code
+    should never actually reach there.
 */
 
 #include <queue/queue.h>
@@ -21,11 +34,13 @@ Initizing queue with 0x00 for a size of MAX_QUEUE_SIZE
 @param queue_t* queue - queue to initialize
 */
 void init_queue(queue_t* queue) {
-    queue->head = 0;
-    queue->tail = 0;
-    for (uint8_t i = 0; i < MAX_QUEUE_SIZE; i++) {
-        for (uint8_t j = 0; j < QUEUE_DATA_SIZE; j++) {
-            queue->content[i][j] = 0x00;
+    ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
+        queue->head = 0;
+        queue->tail = 0;
+        for (uint8_t i = 0; i < MAX_QUEUE_SIZE; i++) {
+            for (uint8_t j = 0; j < QUEUE_DATA_SIZE; j++) {
+                queue->content[i][j] = 0x00;
+            }
         }
     }
 }
@@ -35,7 +50,11 @@ queue - queue to get the size of
 Returns - the size of the queue (number of 8-byte elements)
 */
 uint8_t queue_size(queue_t* queue) {
-    return (queue->tail - queue->head);
+    ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
+        return (queue->tail - queue->head);
+    }
+
+    return 0;
 }
 
 /*
@@ -45,7 +64,11 @@ Checks whether the queue is full
 @return 1 if the queue has reached maximum capacity, 0 otherwise
 */
 uint8_t queue_full(queue_t* queue) {
-    return (queue_size(queue) == MAX_QUEUE_SIZE);
+    ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
+        return (queue_size(queue) == MAX_QUEUE_SIZE);
+    }
+
+    return 0;
 }
 
 /*
@@ -55,7 +78,11 @@ Checks whether the queue is empty
 @return 1 if there are no elements in the queue, 0 otherwise
 */
 uint8_t queue_empty(queue_t* queue) {
-    return (queue_size(queue) == 0);
+    ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
+        return (queue_size(queue) == 0);
+    }
+
+    return 0;
 }
 
 /*
@@ -64,15 +91,17 @@ Shifts all the elements in queue left (to start at index 0)
 @param queue_t* queue - queue to operate on
 */
 void shift_queue_left(queue_t* queue) {
-    for (uint8_t i = queue->head; i < queue->tail; i++) {
-        for (uint8_t j = 0; j < QUEUE_DATA_SIZE; j++) {
-            queue->content[i - queue->head][j] = queue->content[i][j];
-            queue->content[i][j] = 0x00;
+    ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
+        for (uint8_t i = queue->head; i < queue->tail; i++) {
+            for (uint8_t j = 0; j < QUEUE_DATA_SIZE; j++) {
+                queue->content[i - queue->head][j] = queue->content[i][j];
+                queue->content[i][j] = 0x00;
+            }
         }
-    }
 
-    queue->tail = (queue->tail) - (queue->head);
-    queue->head = 0;
+        queue->tail = (queue->tail) - (queue->head);
+        queue->head = 0;
+    }
 }
 
 /*
@@ -83,19 +112,22 @@ Inserts new data at the end of the queue
 @return 1 if data has been added to queue, 0 otherwise
 */
 uint8_t enqueue(queue_t* queue, const uint8_t* data) {
-    if (queue_full(queue)) {
-        return 0;
-    } else {
+    ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
+        if (queue_full(queue)) {
+            return 0;
+        }
+
         if (queue->tail == MAX_QUEUE_SIZE) {
             shift_queue_left(queue);
         }
-        uint8_t index = queue->tail;
         for (uint8_t i = 0; i < QUEUE_DATA_SIZE; i++) {
-            queue->content[index][i] = data[i];
+            queue->content[queue->tail][i] = data[i];
         }
         queue->tail += 1;
         return 1;
     }
+
+    return 0;
 }
 
 /*
@@ -106,17 +138,21 @@ Peeks (gets) the first element of the queue without removing it
 @return 1 if data is valid from queue, 0 otherwise
 */
 uint8_t peek_queue(queue_t* queue, uint8_t* data) {
-    if (queue_empty(queue)) {
-        return 0;
-    }
-
-    if (data != NULL) {
-        for (uint8_t i = 0; i < QUEUE_DATA_SIZE; i++) {
-            data[i] = queue->content[queue->head][i];
+    ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
+        if (queue_empty(queue)) {
+            return 0;
         }
+
+        if (data != NULL) {
+            for (uint8_t i = 0; i < QUEUE_DATA_SIZE; i++) {
+                data[i] = queue->content[queue->head][i];
+            }
+        }
+
+        return 1;
     }
 
-    return 1;
+    return 0;
 }
 
 /*
@@ -127,18 +163,22 @@ Removes and returns the first element of the queue
 @return 1 if data has been removed from queue, 0 otherwise
 */
 uint8_t dequeue(queue_t* queue, uint8_t* data) {
-    if (queue_empty(queue)) {
-        return 0;
+    ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
+        if (queue_empty(queue)) {
+            return 0;
+        }
+
+        // Get the element
+        peek_queue(queue, data);
+
+        // Remove the element
+        for (uint8_t i = 0; i < QUEUE_DATA_SIZE; i++) {
+            queue->content[queue->head][i] = 0x00;
+        }
+        queue->head += 1;
+
+        return 1;
     }
 
-    // Get the element
-    peek_queue(queue, data);
-
-    // Remove the element
-    for (uint8_t i = 0; i < QUEUE_DATA_SIZE; i++) {
-        queue->content[queue->head][i] = 0x00;
-    }
-    queue->head += 1;
-
-    return 1;
+    return 0;
 }


### PR DESCRIPTION
- Wrapped queue functions in `ATOMIC_BLOCK(ATOMIC_RESTORESTATE)` blocks
- Some cleanup of queue functions
- Added `queue_size()` function and updated harness test
