### PR TITLE
Fixed UART print bug for long strings

### DIFF
--- a/examples/uart_print_long/makefile
+++ b/examples/uart_print_long/makefile
@@ -1,0 +1,2 @@
+PROG = uart_print_long
+include ../makefile

--- a/examples/uart_print_long/uart_print_long.c
+++ b/examples/uart_print_long/uart_print_long.c
@@ -1,0 +1,22 @@
+/*
+Tests printing a long string, longer than PRINT_BUF_SIZE (50 characters).
+Check that the behaviour of vsnprintf will cut off the string after 49
+characters (before the NULL character) instead of trying to print the whole thing.
+*/
+
+#include <uart/uart.h>
+
+int main(void) {
+    init_uart();
+
+    // Uncomment one of these lines to test a different baud rate (default 9600)
+    // set_uart_baud_rate(UART_BAUD_1200);
+    // set_uart_baud_rate(UART_BAUD_9600);
+    // set_uart_baud_rate(UART_BAUD_19200);
+    // set_uart_baud_rate(UART_BAUD_115200);
+
+    for(;;) {
+        print("This is a long string, a very long string, a very very long string");
+        print("\n");
+    }
+}

--- a/include/uart/uart.h
+++ b/include/uart/uart.h
@@ -50,7 +50,7 @@ void set_uart_rx_cb(uart_rx_cb_t cb);
 void clear_uart_rx_buf(void);
 
 // Printing (from log.c)
-int16_t print(char* str, ...);
+int16_t print(char* fmt, ...);
 void print_bytes(uint8_t* data, uint8_t len);
 
 #endif // UART_H

--- a/src/uart/log.c
+++ b/src/uart/log.c
@@ -21,11 +21,18 @@ Note: Floating point output (with %f) is not available by default, must add
 str - Format string for the message
 variable arguments - To be substituted for format specifiers
 */
-inline int16_t print(char* str, ...) {
+inline int16_t print(char* fmt, ...) {
     va_list args;
-    va_start(args, str);
+    va_start(args, fmt);
 
-    int16_t ret = vsprintf((char*) print_buf, str, args);
+    /*
+    Note that we use vsnprintf instead of vsprintf to specify the maximum
+    number of characters to be written to print_buf. This is to prevent errors
+    if you try to print a string longer than PRINT_BUF_SIZE, exceeding
+    print_buf and overwriting uart_rx_buf and/or uart_rx_buf_count.
+    See https://www.microchip.com/webdoc/AVRLibcReferenceManual/group__avr__stdio_1gac92e8c42a044c8f50aad5c2c69e638e0.html
+    */
+    int16_t ret = vsnprintf((char*) print_buf, PRINT_BUF_SIZE, fmt, args);
     va_end(args);
 
     send_uart(print_buf, strlen((char*) print_buf));


### PR DESCRIPTION
When attempting to print strings longer than the print buffer (50 characters), they should now cut off instead of corrupting other memory.