### PR TITLE
Test harness fixes and improvements

### DIFF
--- a/bin/harness.py
+++ b/bin/harness.py
@@ -71,7 +71,7 @@ class TestHarness:
     # returns count from harness
     # checks for appropriate input (ok)
     def recv_count(self, suite):
-        ok = input("Connect the programmer TX pin to board RX/SCK or set board switch to RUN. (press enter) ")
+        ok = input("Connect programmer TX pin to board RX/SCK pin or set board switch to RUN. (press enter) ")
 
         # prints '-' 80 times
         print(sep)
@@ -127,7 +127,7 @@ class TestSuite:
     mcu = "m32m1"
     prog = "stk500"
     includes = "-I./include/"
-    lib = "-L./lib/ -ltest -lprintf_flt -lm -luart -lspi -lcan -ltimer -lqueue -lstack -lheartbeat -lwatchdog -lutilities"
+    lib = "-L./lib/ -ltest -lprintf_flt -lm -ladc -lcan -lconversions -ldac -lheartbeat -lpex -lqueue -lspi -lstack -ltimer -luart -lutilities -lwatchdog"
 
     def __init__(self, path, boards, harness):
         self.path = path
@@ -255,6 +255,9 @@ class Test:
             return False
 
     def handle_line(self, line):
+        # Print the raw characters received
+        print("UART RX:", line.strip())
+
         if line == "DONE\r\n":
             (self.time_cb)()
             self.done = True

--- a/include/test/test.h
+++ b/include/test/test.h
@@ -5,35 +5,35 @@
 #include <avr/io.h>
 #include <stdint.h>
 
-#define ASSERT_EQ(a, b) (print("AS EQ %d %d (%s) (%d)\r\n",\
-    (a), (b), __FUNCTION__, __LINE__))
+#define ASSERT_EQ(a, b) (print("AS EQ %ld %ld (%s) (%d)\r\n",\
+    (int32_t)(a), (int32_t)(b), __FUNCTION__, (int16_t)__LINE__))
 
-#define ASSERT_NEQ(a, b) (print("AS NEQ %d %d (%s) (%d)\r\n",\
-    (a), (b), __FUNCTION__, __LINE__))
+#define ASSERT_NEQ(a, b) (print("AS NEQ %ld %ld (%s) (%d)\r\n",\
+    (int32_t)(a), (int32_t)(b), __FUNCTION__, (int16_t)__LINE__))
 
-#define ASSERT_GREATER(a, b) (print("AS GT %d %d (%s) (%d)\r\n",\
-    (a), (b), __FUNCTION__, __LINE__))
+#define ASSERT_GREATER(a, b) (print("AS GT %ld %ld (%s) (%d)\r\n",\
+    (int32_t)(a), (int32_t)(b), __FUNCTION__, (int16_t)__LINE__))
 
-#define ASSERT_LESS(a, b) (print("AS LT %d %d (%s) (%d)\r\n",\
-    (a), (b), __FUNCTION__, __LINE__))
+#define ASSERT_LESS(a, b) (print("AS LT %ld %ld (%s) (%d)\r\n",\
+    (int32_t)(a), (int32_t)(b), __FUNCTION__, (int16_t)__LINE__))
 
-#define ASSERT_TRUE(v) (print("AS TRUE %d (%s) (%d)\r\n",\
-    (v), __FUNCTION__, __LINE__))
+#define ASSERT_TRUE(v) (print("AS TRUE %ld (%s) (%d)\r\n",\
+    (int32_t)(v), __FUNCTION__, (int16_t)__LINE__))
 
-#define ASSERT_FALSE(v) (print("AS FALSE %d (%s) (%d)\r\n",\
-    (v), __FUNCTION__, __LINE__))
+#define ASSERT_FALSE(v) (print("AS FALSE %ld (%s) (%d)\r\n",\
+    (int32_t)(v), __FUNCTION__, (int16_t)__LINE__))
 
 #define ASSERT_FP_EQ(a, b) (print("AS FP EQ %.3f %.3f (%s) (%d)\r\n",\
-    (float)(a), (float)(b), __FUNCTION__, __LINE__))
+    (float)(a), (float)(b), __FUNCTION__, (int16_t)__LINE__))
 
 #define ASSERT_FP_NEQ(a, b) (print("AS FP NEQ %.3f %.3f (%s) (%d)\r\n",\
-    (float)(a), (float)(b), __FUNCTION__, __LINE__))
+    (float)(a), (float)(b), __FUNCTION__, (int16_t)__LINE__))
 
 #define ASSERT_FP_GREATER(a, b) (print("AS FP GT %.3f %.3f (%s) (%d)\r\n",\
-    (float)(a), (float)(b), __FUNCTION__, __LINE__))
+    (float)(a), (float)(b), __FUNCTION__, (int16_t)__LINE__))
 
 #define ASSERT_FP_LESS(a, b) (print("AS FP LT %.3f %.3f (%s) (%d)\r\n",\
-    (float)(a), (float)(b), __FUNCTION__, __LINE__))
+    (float)(a), (float)(b), __FUNCTION__, (int16_t)__LINE__))
 
 typedef void(*test_fn_t)(void);
 

--- a/src/test/test.c
+++ b/src/test/test.c
@@ -3,14 +3,14 @@
 
 #include <util/atomic.h>
 
-#define START_LEN 7
+#define COUNT_MSG "COUNT\r\n"
 #define COUNT_LEN 7
+#define START_MSG "START\r\n"
+#define START_LEN 7
+#define KILL_MSG "KILL\r\n"
 #define KILL_LEN 6
 
-#define COUNT_MSG "COUNT\r\n"
 #define END_MSG "END\r\n"
-#define START_TEST_MSG "START\r\n"
-#define DONE_TEST_MSG "DONE\r\n"
 
 test_t** test_suite;
 uint8_t test_num;
@@ -21,7 +21,7 @@ void run_test(test_t*);
 
 // FIXME: this code is very precarious
 uint8_t test_start_cb(const uint8_t* data, uint8_t len) {
-    char* start = "START\r\n";
+    char* start = START_MSG;
     if (len < START_LEN) return 0;
 
     uint8_t flag = 1;
@@ -43,7 +43,7 @@ uint8_t test_start_cb(const uint8_t* data, uint8_t len) {
 }
 
 uint8_t test_count_cb(const uint8_t* data, uint8_t len) {
-    char* count = "COUNT\r\n";
+    char* count = COUNT_MSG;
     if (len < COUNT_LEN) return 0;
 
     uint8_t flag = 1;
@@ -90,7 +90,7 @@ void run_test(test_t* test) {
 }
 
 uint8_t slave_kill_cb(const uint8_t* data, uint8_t len) {
-    char* kill = "KILL\r\n";
+    char* kill = KILL_MSG;
     if (len < KILL_LEN) return 0;
 
     uint8_t flag = 1;


### PR DESCRIPTION
- For integer arguments in assertion macros, always use `%ld` and cast them to `int32_t`
- Refactored constant strings
- Updated linked libraries
- Print UART RX messages in Python script for debugging
