### PR TITLE
Uptime library

### DIFF
--- a/build/uptime/.gitignore
+++ b/build/uptime/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/examples/makefile
+++ b/examples/makefile
@@ -6,10 +6,15 @@
 
 # Parameters that might need to be changed, depending on the repository
 #-------------------------------------------------------------------------------
+# Path to lib-common (relative to current directory)
+LIB_COMMON = ../..
 # Includes (header files)
-INCLUDES = -I../../include
+INCLUDES = -I$(LIB_COMMON)/include
 # Libraries from lib-common to link
-LIB = -L../../lib -ladc -lcan -lconversions -ldac -lheartbeat -lpex -lqueue -lspi -lstack -ltest -ltimer -luart -lutilities -lwatchdog -lprintf_flt -lm
+# For some reason, conversions needs to come after dac or else it gives an error
+# Need to put dac before conversions, uptime before timer,
+# or else gives an error for undefined reference
+LIB = -L$(LIB_COMMON)/lib -ladc -lcan -ldac -lconversions -lheartbeat -lpex -lqueue -lspi -lstack -ltest -luptime -ltimer -luart -lutilities -lwatchdog -lprintf_flt -lm
 # Name of microcontroller ("32m1" or "64m1")
 MCU = 64m1
 #-------------------------------------------------------------------------------
@@ -126,8 +131,8 @@ lib-common:
 	@echo "Fetching latest version of lib-common..."
 	git submodule update --remote
 	@echo "Compiling lib-common..."
-	make -C ../../lib-common clean
-	make -C ../../lib-common
+	make -C $(LIB_COMMON) clean MCU=$(MCU)
+	make -C $(LIB_COMMON) MCU=$(MCU)
 
 # Create a file called eeprom.bin, which contains a raw binary copy of the micro's EEPROM memory.
 # View the contents of the binary file in hex
@@ -143,4 +148,4 @@ endif
 
 # Upload .hex program to device
 upload: $(PROG)
-	avrdude -p $(DEVICE) -c $(PGMR) -P $(PORT) -U flash:w:./$^.hex
+	avrdude -p $(DEVICE) -c $(PGMR) -C $(LIB_COMMON)/avrdude.conf -P $(PORT) -U flash:w:./$^.hex

--- a/harness_tests/makefile
+++ b/harness_tests/makefile
@@ -6,10 +6,15 @@
 
 # Parameters that might need to be changed, depending on the repository
 #-------------------------------------------------------------------------------
+# Path to lib-common (relative to current directory)
+LIB_COMMON = ../..
 # Includes (header files)
-INCLUDES = -I../../include
+INCLUDES = -I$(LIB_COMMON)/include
 # Libraries from lib-common to link
-LIB = -L../../lib -ladc -lcan -lconversions -ldac -lheartbeat -lpex -lqueue -lspi -lstack -ltest -ltimer -luart -lutilities -lwatchdog -lprintf_flt -lm
+# For some reason, conversions needs to come after dac or else it gives an error
+# Need to put dac before conversions, uptime before timer,
+# or else gives an error for undefined reference
+LIB = -L$(LIB_COMMON)/lib -ladc -lcan -ldac -lconversions -lheartbeat -lpex -lqueue -lspi -lstack -ltest -luptime -ltimer -luart -lutilities -lwatchdog -lprintf_flt -lm
 # Name of microcontroller ("32m1" or "64m1")
 MCU = 64m1
 #-------------------------------------------------------------------------------
@@ -126,8 +131,8 @@ lib-common:
 	@echo "Fetching latest version of lib-common..."
 	git submodule update --remote
 	@echo "Compiling lib-common..."
-	make -C ../../lib-common clean
-	make -C ../../lib-common
+	make -C $(LIB_COMMON) clean MCU=$(MCU)
+	make -C $(LIB_COMMON) MCU=$(MCU)
 
 # Create a file called eeprom.bin, which contains a raw binary copy of the micro's EEPROM memory.
 # View the contents of the binary file in hex
@@ -143,4 +148,4 @@ endif
 
 # Upload .hex program to device
 upload: $(PROG)
-	avrdude -p $(DEVICE) -c $(PGMR) -P $(PORT) -U flash:w:./$^.hex
+	avrdude -p $(DEVICE) -c $(PGMR) -C $(LIB_COMMON)/avrdude.conf -P $(PORT) -U flash:w:./$^.hex

--- a/include/uptime/uptime.h
+++ b/include/uptime/uptime.h
@@ -8,12 +8,6 @@
 #include <timer/timer.h>
 #include <uart/uart.h>
 
-#include "rtc.h"
-
-// Default double word (4-byte) value in EEPROM
-// TODO - put in lib-common/utilities
-#define EEPROM_DEF_DWORD 0xFFFFFFFF
-
 // EEPROM address for storing number of resets
 #define RESTART_COUNT_EEPROM_ADDR ((uint32_t*) 0x60)
 
@@ -26,12 +20,9 @@
 typedef void(*uptime_fn_t)(void);
 
 extern uint32_t restart_count;
-extern rtc_date_t restart_date;
-extern rtc_time_t restart_time;
-
 extern volatile uint32_t uptime_s;
 
-void init_uptime(rtc_date_t date, rtc_time_t time);
+void init_uptime(void);
 void update_restart_count(void);
 uint8_t add_uptime_callback(uptime_fn_t callback);
 

--- a/include/uptime/uptime.h
+++ b/include/uptime/uptime.h
@@ -1,0 +1,38 @@
+#ifndef UPTIME_H
+#define UPTIME_H
+
+#include <stdint.h>
+
+#include <avr/eeprom.h>
+
+#include <timer/timer.h>
+#include <uart/uart.h>
+
+#include "rtc.h"
+
+// Default double word (4-byte) value in EEPROM
+// TODO - put in lib-common/utilities
+#define EEPROM_DEF_DWORD 0xFFFFFFFF
+
+// EEPROM address for storing number of resets
+#define RESTART_COUNT_EEPROM_ADDR ((uint32_t*) 0x60)
+
+// Number of seconds between timer callbacks
+#define UPTIME_TIMER_PERIOD 1
+
+// Number of functions to be called from the same timer
+#define UPTIME_NUM_CALLBACKS 5
+
+typedef void(*uptime_fn_t)(void);
+
+extern uint32_t restart_count;
+extern rtc_date_t restart_date;
+extern rtc_time_t restart_time;
+
+extern volatile uint32_t uptime_s;
+
+void init_uptime(rtc_date_t date, rtc_time_t time);
+void update_restart_count(void);
+uint8_t add_uptime_callback(uptime_fn_t callback);
+
+#endif

--- a/makefile
+++ b/makefile
@@ -1,6 +1,6 @@
 # All libraries (subdirectories/folders) in lib-common
 # Need to put uart first because other libraries depend on it (otherwise get error of "No rule to make target...")
-LIBNAMES = uart adc can conversions dac heartbeat pex queue spi stack test timer utilities watchdog
+LIBNAMES = uart adc can conversions dac heartbeat pex queue spi stack test timer uptime utilities watchdog
 # Subfolders in src folder
 SRC = $(addprefix src/,$(LIBNAMES))
 # Subfolders in build folder

--- a/manual_tests/makefile
+++ b/manual_tests/makefile
@@ -6,10 +6,15 @@
 
 # Parameters that might need to be changed, depending on the repository
 #-------------------------------------------------------------------------------
+# Path to lib-common (relative to current directory)
+LIB_COMMON = ../..
 # Includes (header files)
-INCLUDES = -I../../include
+INCLUDES = -I$(LIB_COMMON)/include
 # Libraries from lib-common to link
-LIB = -L../../lib -ladc -lcan -ldac -lconversions -lheartbeat -lpex -lqueue -lspi -lstack -ltest -ltimer -luart -lutilities -lwatchdog -lprintf_flt -lm
+# For some reason, conversions needs to come after dac or else it gives an error
+# Need to put dac before conversions, uptime before timer,
+# or else gives an error for undefined reference
+LIB = -L$(LIB_COMMON)/lib -ladc -lcan -ldac -lconversions -lheartbeat -lpex -lqueue -lspi -lstack -ltest -luptime -ltimer -luart -lutilities -lwatchdog -lprintf_flt -lm
 # Name of microcontroller ("32m1" or "64m1")
 MCU = 64m1
 #-------------------------------------------------------------------------------
@@ -126,8 +131,8 @@ lib-common:
 	@echo "Fetching latest version of lib-common..."
 	git submodule update --remote
 	@echo "Compiling lib-common..."
-	make -C ../../lib-common clean
-	make -C ../../lib-common
+	make -C $(LIB_COMMON) clean MCU=$(MCU)
+	make -C $(LIB_COMMON) MCU=$(MCU)
 
 # Create a file called eeprom.bin, which contains a raw binary copy of the micro's EEPROM memory.
 # View the contents of the binary file in hex
@@ -143,4 +148,4 @@ endif
 
 # Upload .hex program to device
 upload: $(PROG)
-	avrdude -p $(DEVICE) -c $(PGMR) -C ../../avrdude.conf -P $(PORT) -U flash:w:./$^.hex
+	avrdude -p $(DEVICE) -c $(PGMR) -C $(LIB_COMMON)/avrdude.conf -P $(PORT) -U flash:w:./$^.hex

--- a/manual_tests/uptime_test/makefile
+++ b/manual_tests/uptime_test/makefile
@@ -1,0 +1,2 @@
+PROG = uptime_test
+include ../makefile

--- a/manual_tests/uptime_test/uptime_test.c
+++ b/manual_tests/uptime_test/uptime_test.c
@@ -1,0 +1,90 @@
+/*
+This program tests initialization of the restart count (read EEPROM, increment,
+write EEPROM) and continuous updating of the OBC uptime.
+*/
+
+#include "../../src/uptime.h"
+
+uint8_t counts[6] = {0};
+
+void print_counts(void) {
+    print("uptime: %lu\n", uptime_s);
+    print("counts:");
+    for (uint8_t i = 0; i < 6; i++) {
+        print(" %u", counts[i]);
+    }
+    print("\n");
+}
+
+void func0(void) {
+    counts[0] += 1;
+}
+
+void func1(void) {
+    counts[1] += 1;
+}
+
+void func2(void) {
+    counts[2] += 1;
+}
+
+void func3(void) {
+    counts[3] += 1;
+}
+
+void func4(void) {
+    counts[4] += 1;
+}
+
+void func5(void) {
+    counts[5] += 1;
+}
+
+void wait(void) {
+    print_counts();
+    print("Waiting 5 seconds...\n");
+    _delay_ms(5000);
+    print("Done waiting\n");
+    print_counts();
+}
+
+int main(void) {
+    init_uart();
+
+    print("\n\n\nStarting uptime test\n\n");
+    rtc_date_t date = { .yy = 03, .mm = 11, .dd = 21 };
+    rtc_time_t time = { .hh = 07, .mm = 03, .ss = 59 };
+    init_uptime(date, time);
+    print("Initialized uptime\n");
+
+    print("restart_count = %lu\n", restart_count);
+    print("restart_date = %u:%u:%u\n", restart_date.yy, restart_date.mm, restart_date.dd);
+    print("restart_time = %u:%u:%u\n", restart_time.hh, restart_time.mm, restart_time.ss);
+    print("uptime_s = %lu\n", uptime_s);
+
+    wait();
+
+    add_uptime_callback(func0);
+    print("Added func0\n");
+
+    wait();
+
+    add_uptime_callback(func1);
+    add_uptime_callback(func2);
+    add_uptime_callback(func3);
+    print("Added func1, func2, func3\n");
+
+    wait();
+
+    add_uptime_callback(func4);
+    print("Added func4\n");
+
+    wait();
+
+    add_uptime_callback(func5);
+    print("Added func5 - should not be called\n");
+
+    wait();
+
+    print("Done test\n");
+}

--- a/manual_tests/uptime_test/uptime_test.c
+++ b/manual_tests/uptime_test/uptime_test.c
@@ -1,9 +1,9 @@
 /*
 This program tests initialization of the restart count (read EEPROM, increment,
-write EEPROM) and continuous updating of the OBC uptime.
+write EEPROM) and continuous updating of the MCU uptime.
 */
 
-#include "../../src/uptime.h"
+#include <uptime/uptime.h>
 
 uint8_t counts[6] = {0};
 
@@ -52,14 +52,10 @@ int main(void) {
     init_uart();
 
     print("\n\n\nStarting uptime test\n\n");
-    rtc_date_t date = { .yy = 03, .mm = 11, .dd = 21 };
-    rtc_time_t time = { .hh = 07, .mm = 03, .ss = 59 };
-    init_uptime(date, time);
+    init_uptime();
     print("Initialized uptime\n");
 
     print("restart_count = %lu\n", restart_count);
-    print("restart_date = %u:%u:%u\n", restart_date.yy, restart_date.mm, restart_date.dd);
-    print("restart_time = %u:%u:%u\n", restart_time.hh, restart_time.mm, restart_time.ss);
     print("uptime_s = %lu\n", uptime_s);
 
     wait();

--- a/src/uptime/makefile
+++ b/src/uptime/makefile
@@ -1,0 +1,2 @@
+LIBNAME = uptime
+include ../makefile

--- a/src/uptime/uptime.c
+++ b/src/uptime/uptime.c
@@ -1,0 +1,91 @@
+/*
+Functionality to track a global uptime (in seconds since last restart) across
+all of OBC using the 8-bit timer. Also tracks the number of times OBC has
+restarted using EEPROM.
+
+This library basically multiplexes a set of timer callbacks onto a single timer
+(the 8-bit timer). You can add multiple callbcaks, which will all be called
+around the same time every second. They can read the `uptime_s` variable to
+decide what to do.
+*/
+
+#include "uptime.h"
+
+// Variables  modified inside the timer interrupt must be volatile
+// Note that 1 billion seconds is about 31.7 years (reasoning for using 32-bit
+// uptime_s variable)
+
+// Number of times OBC has started up, i.e. how many times the program has
+// started from the beginning (includes 1 for the first time)
+uint32_t restart_count = 0;
+// Date and time of the most recent restart
+rtc_date_t restart_date = { .yy = 0, .mm = 0, .dd  = 0 };
+rtc_time_t restart_time = { .hh = 0, .mm = 0, .ss  = 0 };
+
+// OBC uptime (in seconds) - since most recent restart
+volatile uint32_t uptime_s = 0;
+
+// No-op default callbacks
+void uptime_fn_nop(void) {}
+
+// Array of timer callbacks for uptime timer callback
+uptime_fn_t uptime_callbacks[UPTIME_NUM_CALLBACKS] = {uptime_fn_nop};
+
+void uptime_timer_cb(void);
+
+
+void init_uptime(rtc_date_t date, rtc_time_t time) {
+    // Update restart count
+    update_restart_count();
+
+    // Set the date and time
+    restart_date = date;
+    restart_time = time;
+
+    // Set all callbacks to no-op initially, just in case
+    for (uint8_t i = 0; i < UPTIME_NUM_CALLBACKS; i++) {
+        uptime_callbacks[i] = uptime_fn_nop;
+    }
+
+    // Initialize timer to go off at regular intervals
+    start_timer_8bit(UPTIME_TIMER_PERIOD, uptime_timer_cb);
+}
+
+void update_restart_count(void) {
+    // Read the restart count stored in EEPROM
+    restart_count = eeprom_read_dword(RESTART_COUNT_EEPROM_ADDR);
+    if (restart_count == EEPROM_DEF_DWORD) {
+        restart_count = 0;
+    }
+
+    // Increment the restart count and write it back to EEPROM
+    restart_count++;
+    eeprom_write_dword(RESTART_COUNT_EEPROM_ADDR, restart_count);
+}
+
+// Adds a callback to the next available spot in the array
+// Returns - 1 for success, 0 for failure (no spots left)
+uint8_t add_uptime_callback(uptime_fn_t callback) {
+    for (uint8_t i = 0; i < UPTIME_NUM_CALLBACKS; i++) {
+        if (uptime_callbacks[i] == uptime_fn_nop) {
+            uptime_callbacks[i] = callback;
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+// This timer should be called repeatedly (every 1 second) to keep track of uptime
+void uptime_timer_cb(void) {
+    // Update uptime
+    uptime_s += UPTIME_TIMER_PERIOD;
+
+    // print("uptime timer cb\n");
+    // print("uptime_s = %lu\n", uptime_s);
+
+    // Call all of the callback functions
+    for (uint8_t i = 0; i < UPTIME_NUM_CALLBACKS; i++) {
+        uptime_callbacks[i]();
+    }
+}


### PR DESCRIPTION
Moved the uptime library from obc to lib-common for tracking program uptime and multiplexing callbacks onto the 8-bit timer. Also updated makefiles.

API changes:
- `init_uptime(rtc_date_t, rtc_time_t)` -> `init_uptime(void)`
- `restart_date`, `restart_time` - removed