### PR TITLE
Heartbeat reset implementation and cleanup

### DIFF
--- a/examples/heartbeat_basic/heartbeat_basic.c
+++ b/examples/heartbeat_basic/heartbeat_basic.c
@@ -1,6 +1,6 @@
 /*
     Heartbeat Protocol:
-        (1) In SSM main program, input ssm_id,(OBC, PAY, EPS)
+        (1) In SSM main program, input hb_self_id,(OBC, PAY, EPS)
         as per line 37
         (2) Call init_heartbeat() to set up heartbeat SSM
         configuration. See documented details in heartbeat.c
@@ -27,7 +27,7 @@ extern uint8_t* child_status;
 extern uint8_t receiving_id; // obc {0x00} eps {0x02} pay {0x01}
 extern uint8_t fresh_start;
 
-uint8_t ssm_id; // User define ssm_id in main program
+uint8_t hb_self_id; // User define hb_self_id in main program
 
 // This main function simulates the example file in lib-common
 int main() {
@@ -35,9 +35,7 @@ int main() {
     init_can();
 
     // Input SSM_ID: vital to heartbeat
-    ssm_id = OBC;
-
-    init_heartbeat();
+    init_heartbeat(HB_OBC);
     print("heartbeat initialized\n");
     print("obc %d, pay %d, eps %d\n", obc_status, pay_status, eps_status);
 

--- a/include/heartbeat/heartbeat.h
+++ b/include/heartbeat/heartbeat.h
@@ -46,14 +46,14 @@
 // TODO - update pin definitions from PAY outputs
 
 // PAY resets OBC
-#define HB_PAY_RST_OBC_PIN  PD7
-#define HB_PAY_RST_OBC_PORT PORTD
-#define HB_PAY_RST_OBC_DDR  DDRD
+#define HB_PAY_RST_OBC_PIN  PC5
+#define HB_PAY_RST_OBC_PORT PORTC
+#define HB_PAY_RST_OBC_DDR  DDRC
 
 // PAY resets EPS
-#define HB_PAY_RST_EPS_PIN  PD7
-#define HB_PAY_RST_EPS_PORT PORTD
-#define HB_PAY_RST_EPS_DDR  DDRD
+#define HB_PAY_RST_EPS_PIN  PC4
+#define HB_PAY_RST_EPS_PORT PORTC
+#define HB_PAY_RST_EPS_DDR  DDRC
 
 
 // Store SSM status as global variables

--- a/include/heartbeat/heartbeat.h
+++ b/include/heartbeat/heartbeat.h
@@ -19,9 +19,9 @@
 #define DEADBEEF 0xdeadbeef //4 bytes
 
 // Define SSM ids
-#define OBC 0x00
-#define EPS 0x02
-#define PAY 0x01
+#define HB_OBC 0x00
+#define HB_PAY 0x01
+#define HB_EPS 0x02
 
 // OBC resets EPS
 #define HB_OBC_RST_EPS_PIN  PC4
@@ -68,9 +68,10 @@ extern uint8_t* self_status;
 extern uint8_t* parent_status;
 extern uint8_t* child_status;
 
-// Declare global variables for ssm_id and receiving_id
+// Declare global variables for hb_self_id and receiving_id
 // obc {0x00} eps {0x02} pay {0x01}
-extern uint8_t ssm_id;
+extern uint8_t hb_self_id;
+
 extern uint8_t receiving_id;
 
 extern mob_t status_rx_mob;
@@ -78,6 +79,10 @@ extern mob_t status_tx_mob;
 
 // Declare fresh_start as global var. to keep track of fresh start and restart
 extern uint8_t fresh_start; // 1 when board has a fresh start, 0 otherwise
+
+// Other heartbeat functions
+void assign_heartbeat_status(void);
+void assign_status_message_objects(void);
 
 // Declare heartbeat functions (Users only use the first 2)
 void init_heartbeat(uint8_t id);

--- a/include/heartbeat/heartbeat.h
+++ b/include/heartbeat/heartbeat.h
@@ -1,6 +1,11 @@
 #ifndef HEARTBEAT_H
 #define HEARTBEAT_H
 
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <can/can.h>
+
 // CAN ids of each SSMs.
 // Currently DOES NOT follow the convention of can_ids in lib-common master
 #define OBC_STATUS_RX_MOB_ID 0x001c
@@ -17,6 +22,39 @@
 #define OBC 0x00
 #define EPS 0x02
 #define PAY 0x01
+
+// OBC resets EPS
+#define HB_OBC_RST_EPS_PIN  PC4
+#define HB_OBC_RST_EPS_PORT PORTC
+#define HB_OBC_RST_EPS_DDR  DDRC
+
+// OBC resets PAY
+#define HB_OBC_RST_PAY_PIN  PC5
+#define HB_OBC_RST_PAY_PORT PORTC
+#define HB_OBC_RST_PAY_DDR  DDRC
+
+// EPS resets OBC
+#define HB_EPS_RST_OBC_PIN  PC6
+#define HB_EPS_RST_OBC_PORT PORTC
+#define HB_EPS_RST_OBC_DDR  DDRC
+
+// EPS resets PAY
+#define HB_EPS_RST_PAY_PIN  PC5
+#define HB_EPS_RST_PAY_PORT PORTC
+#define HB_EPS_RST_PAY_DDR  DDRC
+
+// TODO - update pin definitions from PAY outputs
+
+// PAY resets OBC
+#define HB_PAY_RST_OBC_PIN  PD7
+#define HB_PAY_RST_OBC_PORT PORTD
+#define HB_PAY_RST_OBC_DDR  DDRD
+
+// PAY resets EPS
+#define HB_PAY_RST_EPS_PIN  PD7
+#define HB_PAY_RST_EPS_PORT PORTD
+#define HB_PAY_RST_EPS_DDR  DDRD
+
 
 // Store SSM status as global variables
 extern uint8_t obc_status;
@@ -42,7 +80,9 @@ extern mob_t status_tx_mob;
 extern uint8_t fresh_start; // 1 when board has a fresh start, 0 otherwise
 
 // Declare heartbeat functions (Users only use the first 2)
-void init_heartbeat();
+void init_heartbeat(uint8_t id);
 void heartbeat();
+
+bool send_heartbeat_reset(uint8_t id);
 
 #endif // HEARTBEAT_H

--- a/manual_tests/heartbeat_reset_test/heartbeat_reset_test.c
+++ b/manual_tests/heartbeat_reset_test/heartbeat_reset_test.c
@@ -1,0 +1,107 @@
+/*
+Just test the ability for each MCU to trigger the resets on the other two MCUs.
+*/
+
+#include <heartbeat/heartbeat.h>
+#include <uart/uart.h>
+
+// NOTE: Change this variable before re-compiling and re-uploading to match the
+// subsystem of the board you are uploading to
+uint8_t id = OBC;
+
+void print_cmds(void) {
+    switch (id) {
+        case OBC:
+            print("1. Reset EPS\n");
+            print("2. Reset PAY\n");
+            break;
+        case EPS:
+            print("1. Reset OBC\n");
+            print("2. Reset PAY\n");
+            break;
+        case PAY:
+            print("1. Reset OBC\n");
+            print("2. Reset EPS\n");
+            break;
+        default:
+            break;
+    }
+}
+
+uint8_t uart_cb(uint8_t* data, uint8_t len) {
+    uint8_t c = data[0];
+
+    if (c == 'h') {
+        print_cmds();
+        return 1;
+    }
+    
+    else if (c == '1') {
+        switch (id) {
+            case OBC:
+                print("Resetting EPS");
+                send_heartbeat_reset(EPS);
+                break;
+            case EPS:
+                print("Resetting OBC");
+                send_heartbeat_reset(OBC);
+                break;
+            case PAY:
+                print("Resetting OBC");
+                send_heartbeat_reset(OBC);
+                break;
+            default:
+                break;
+        }
+    }
+    
+    else if (c == '2') {
+        switch (id) {
+            case OBC:
+                print("Resetting PAY");
+                send_heartbeat_reset(PAY);
+                break;
+            case EPS:
+                print("Resetting PAY");
+                send_heartbeat_reset(PAY);
+                break;
+            case PAY:
+                print("Resetting EPS");
+                send_heartbeat_reset(EPS);
+                break;
+            default:
+                break;
+        }
+    }
+    
+    else {
+        print("Invalid command\n");
+    }
+
+    return 1;
+}
+
+int main() {
+    init_uart();
+    print("Starting hearbeat reset test\n");
+
+    print("Self ID = ");
+    if (id == OBC) {
+        print("OBC");
+    } else if (id == EPS) {
+        print("EPS");
+    } else if (id == PAY) {
+        print("PAY");
+    }
+    print("\n");
+
+    print("Initializing heartbeat...\n");
+    init_heartbeat(id);
+    print("Done init\n");
+
+    print_cmds();
+    print("Press 'h' at any time to list the commands\n");
+    while (1) {}
+    
+    return 0;
+}

--- a/manual_tests/heartbeat_reset_test/heartbeat_reset_test.c
+++ b/manual_tests/heartbeat_reset_test/heartbeat_reset_test.c
@@ -7,19 +7,19 @@ Just test the ability for each MCU to trigger the resets on the other two MCUs.
 
 // NOTE: Change this variable before re-compiling and re-uploading to match the
 // subsystem of the board you are uploading to
-uint8_t id = OBC;
+uint8_t id = HB_OBC;
 
 void print_cmds(void) {
     switch (id) {
-        case OBC:
+        case HB_OBC:
             print("1. Reset EPS\n");
             print("2. Reset PAY\n");
             break;
-        case EPS:
+        case HB_EPS:
             print("1. Reset OBC\n");
             print("2. Reset PAY\n");
             break;
-        case PAY:
+        case HB_PAY:
             print("1. Reset OBC\n");
             print("2. Reset EPS\n");
             break;
@@ -38,17 +38,17 @@ uint8_t uart_cb(uint8_t* data, uint8_t len) {
     
     else if (c == '1') {
         switch (id) {
-            case OBC:
+            case HB_OBC:
                 print("Resetting EPS");
-                send_heartbeat_reset(EPS);
+                send_heartbeat_reset(HB_EPS);
                 break;
-            case EPS:
+            case HB_EPS:
                 print("Resetting OBC");
-                send_heartbeat_reset(OBC);
+                send_heartbeat_reset(HB_OBC);
                 break;
-            case PAY:
+            case HB_PAY:
                 print("Resetting OBC");
-                send_heartbeat_reset(OBC);
+                send_heartbeat_reset(HB_OBC);
                 break;
             default:
                 break;
@@ -57,17 +57,17 @@ uint8_t uart_cb(uint8_t* data, uint8_t len) {
     
     else if (c == '2') {
         switch (id) {
-            case OBC:
+            case HB_OBC:
                 print("Resetting PAY");
-                send_heartbeat_reset(PAY);
+                send_heartbeat_reset(HB_PAY);
                 break;
-            case EPS:
+            case HB_EPS:
                 print("Resetting PAY");
-                send_heartbeat_reset(PAY);
+                send_heartbeat_reset(HB_PAY);
                 break;
-            case PAY:
+            case HB_PAY:
                 print("Resetting EPS");
-                send_heartbeat_reset(EPS);
+                send_heartbeat_reset(HB_EPS);
                 break;
             default:
                 break;
@@ -86,11 +86,11 @@ int main() {
     print("Starting hearbeat reset test\n");
 
     print("Self ID = ");
-    if (id == OBC) {
+    if (id == HB_OBC) {
         print("OBC");
-    } else if (id == EPS) {
+    } else if (id == HB_EPS) {
         print("EPS");
-    } else if (id == PAY) {
+    } else if (id == HB_PAY) {
         print("PAY");
     }
     print("\n");

--- a/manual_tests/heartbeat_reset_test/heartbeat_reset_test.c
+++ b/manual_tests/heartbeat_reset_test/heartbeat_reset_test.c
@@ -28,7 +28,7 @@ void print_cmds(void) {
     }
 }
 
-uint8_t uart_cb(uint8_t* data, uint8_t len) {
+uint8_t uart_cb(const uint8_t* data, uint8_t len) {
     uint8_t c = data[0];
 
     if (c == 'h') {
@@ -39,15 +39,15 @@ uint8_t uart_cb(uint8_t* data, uint8_t len) {
     else if (c == '1') {
         switch (id) {
             case HB_OBC:
-                print("Resetting EPS");
+                print("Resetting EPS\n");
                 send_heartbeat_reset(HB_EPS);
                 break;
             case HB_EPS:
-                print("Resetting OBC");
+                print("Resetting OBC\n");
                 send_heartbeat_reset(HB_OBC);
                 break;
             case HB_PAY:
-                print("Resetting OBC");
+                print("Resetting OBC\n");
                 send_heartbeat_reset(HB_OBC);
                 break;
             default:
@@ -58,15 +58,15 @@ uint8_t uart_cb(uint8_t* data, uint8_t len) {
     else if (c == '2') {
         switch (id) {
             case HB_OBC:
-                print("Resetting PAY");
+                print("Resetting PAY\n");
                 send_heartbeat_reset(HB_PAY);
                 break;
             case HB_EPS:
-                print("Resetting PAY");
+                print("Resetting PAY\n");
                 send_heartbeat_reset(HB_PAY);
                 break;
             case HB_PAY:
-                print("Resetting EPS");
+                print("Resetting EPS\n");
                 send_heartbeat_reset(HB_EPS);
                 break;
             default:
@@ -83,7 +83,9 @@ uint8_t uart_cb(uint8_t* data, uint8_t len) {
 
 int main() {
     init_uart();
-    print("Starting hearbeat reset test\n");
+    print("\n\n\nStarting hearbeat reset test\n");
+    set_uart_rx_cb(uart_cb);
+    print("Set UART RX CB\n");
 
     print("Self ID = ");
     if (id == HB_OBC) {

--- a/manual_tests/heartbeat_reset_test/makefile
+++ b/manual_tests/heartbeat_reset_test/makefile
@@ -1,0 +1,2 @@
+PROG = heartbeat_reset_test
+include ../makefile

--- a/manual_tests/makefile
+++ b/manual_tests/makefile
@@ -12,9 +12,9 @@ LIB_COMMON = ../..
 INCLUDES = -I$(LIB_COMMON)/include
 # Libraries from lib-common to link
 # For some reason, conversions needs to come after dac or else it gives an error
-# Need to put dac before conversions, uptime before timer,
+# Need to put dac before conversions, uptime before timer, heartbeat before can,
 # or else gives an error for undefined reference
-LIB = -L$(LIB_COMMON)/lib -ladc -lcan -ldac -lconversions -lheartbeat -lpex -lqueue -lspi -lstack -ltest -luptime -ltimer -luart -lutilities -lwatchdog -lprintf_flt -lm
+LIB = -L$(LIB_COMMON)/lib -ladc -lheartbeat -lcan -ldac -lconversions -lpex -lqueue -lspi -lstack -ltest -luptime -ltimer -luart -lutilities -lwatchdog -lprintf_flt -lm
 # Name of microcontroller ("32m1" or "64m1")
 MCU = 64m1
 #-------------------------------------------------------------------------------

--- a/src/heartbeat/heartbeat.c
+++ b/src/heartbeat/heartbeat.c
@@ -145,7 +145,7 @@ void init_heartbeat(uint8_t self_id) {
             return;
     }
 
-    // See table on p.96 - by default, need tri-state (DDR = 0, PORT = 0)
+    // See table on p.96 - by default, need tri-state input with pullup (DDR = 0, PORT = 1)
     init_input_pin(rst_pin_1.pin, rst_pin_1.ddr);
     set_pin_pullup(rst_pin_1.pin, rst_pin_1.port, 1);
     init_input_pin(rst_pin_2.pin, rst_pin_2.ddr);
@@ -308,14 +308,11 @@ bool send_heartbeat_reset(uint8_t other_id) {
     // Assert the reset
     // TODO - how long?
     // See table on p.96 - for reset, need to output low (DDR = 1, PORT = 0)
-    // Then go back to tri-state (DDR = 0, PORT = 0)
-    print("DDRC = %.2x, PORTC = %.2x\n", DDRC, PORTC);
+    // Then go back to tri-state input with pullup (DDR = 0, PORT = 1)
     init_output_pin(rst_pin.pin, rst_pin.ddr, 0);
-    print("DDRC = %.2x, PORTC = %.2x\n", DDRC, PORTC);
     _delay_ms(100);
     init_input_pin(rst_pin.pin, rst_pin.ddr);
     set_pin_pullup(rst_pin.pin, rst_pin.port, 1);
-    print("DDRC = %.2x, PORTC = %.2x\n", DDRC, PORTC);
 
     return true;
 }


### PR DESCRIPTION
- Implemented the ability for each of the 3 subsystems to be able to reset the other 2
  - The policy for when to reset is not decided/implemented yet, it's currently only a test to press a key to activate the reset
  - Currently only tested between OBC and EPS
- Clarified initialization and naming of variables and constants
