### PR TITLE
UART improvements

### DIFF
--- a/examples/uart_print_bytes/makefile
+++ b/examples/uart_print_bytes/makefile
@@ -1,0 +1,2 @@
+PROG = uart_print_bytes
+include ../makefile

--- a/examples/uart_print_bytes/uart_print_bytes.c
+++ b/examples/uart_print_bytes/uart_print_bytes.c
@@ -1,0 +1,20 @@
+#include <uart/uart.h>
+
+int main(void) {
+    init_uart();
+
+    print("\n\nStart\n");
+
+    uint8_t bytes_1[6] = {0x41, 0xA3, 0xFF, 0x00, 0x07, 0xB0};
+    print_bytes(bytes_1, 6);
+
+    // Test length >= 256 (for uint16_t instead of uint8_t)
+    // Should be 0, 3, 6, ..., 255, 2, 5, 8, ..., 254, 1, ..., 253, 0, ..., 129
+    uint8_t bytes_2[300] = {0x00};
+    for (uint16_t i = 0; i < 300; i++) {
+        bytes_2[i] = i * 3;
+    }
+    print_bytes(bytes_2, 300);
+
+    print("Done\n");
+}

--- a/include/uart/uart.h
+++ b/include/uart/uart.h
@@ -51,6 +51,6 @@ void clear_uart_rx_buf(void);
 
 // Printing (from log.c)
 int16_t print(char* fmt, ...);
-void print_bytes(uint8_t* data, uint8_t len);
+void print_bytes(uint8_t* data, uint16_t len);
 
 #endif // UART_H

--- a/include/uart/uart.h
+++ b/include/uart/uart.h
@@ -47,6 +47,7 @@ void put_uart_char(uint8_t c);
 void get_uart_char(uint8_t* c);
 void send_uart(const uint8_t* msg, uint8_t len);
 void set_uart_rx_cb(uart_rx_cb_t cb);
+uint8_t get_uart_rx_buf_count(void);
 void clear_uart_rx_buf(void);
 
 // Printing (from log.c)

--- a/src/uart/log.c
+++ b/src/uart/log.c
@@ -44,10 +44,13 @@ Prints an array of bytes in hex format on the same line.
 data - pointer to beginning of array
 len - number of bytes in array
 */
-void print_bytes(uint8_t* data, uint8_t len) {
-    for (uint8_t i = 0; i < len; i++) {
-        print("0x%.2x ", data[i]);
+void print_bytes(uint8_t* data, uint16_t len) {
+    if (len == 0) {
+        return;
     }
-
+    print("%.2x", data[0]);
+    for (uint16_t i = 1; i < len; i++) {
+        print(":%.2x", data[i]);
+    }
     print("\n");
 }

--- a/src/uart/uart.c
+++ b/src/uart/uart.c
@@ -20,11 +20,11 @@ volatile uint8_t uart_rx_buf[UART_MAX_RX_BUF_SIZE];
 volatile uint8_t uart_rx_buf_count;
 
 // default rx callback (no operation)
-uint8_t _nop(const uint8_t* c, uint8_t len) {
+uint8_t _uart_rx_cb_nop(const uint8_t* c, uint8_t len) {
     return 0;
 }
 // Global RX callback function
-uart_rx_cb_t uart_rx_cb = _nop;
+uart_rx_cb_t uart_rx_cb = _uart_rx_cb_nop;
 
 
 
@@ -53,7 +53,7 @@ void init_uart(void) {
     // reset RX buffer and counter
     clear_uart_rx_buf();
     // Set default (no operation) RX callback
-    uart_rx_cb = _nop;
+    uart_rx_cb = _uart_rx_cb_nop;
 
     // globally enable interrupts
     sei();
@@ -172,12 +172,22 @@ void set_uart_rx_cb(uart_rx_cb_t cb) {
 }
 
 /*
+Gets the number of characters that are currently in the UART RX buffer but have
+not been processed yet.
+*/
+uint8_t get_uart_rx_buf_count(void) {
+    return uart_rx_buf_count;
+}
+
+/*
 Clears the RX buffer (sets all values in the array to 0, sets counter to 0).
 */
 void clear_uart_rx_buf(void) {
-    uart_rx_buf_count = 0;
-    for (uint8_t i = 0; i < UART_MAX_RX_BUF_SIZE; i++) {
-        uart_rx_buf[i] = 0;
+    ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
+        uart_rx_buf_count = 0;
+        for (uint8_t i = 0; i < UART_MAX_RX_BUF_SIZE; i++) {
+            uart_rx_buf[i] = 0;
+        }
     }
 }
 


### PR DESCRIPTION
- Modified output format of `print_bytes()` to be more compact
- Changed `len` input of `print_bytes()` from `uint8_t` -> `uint16_t` - can now print messages > 255 bytes
- Added function to get UART RX buffer count
- Added atomics
- Cleanup