### PR TITLE
Can Review and Bus-Off Interrupts

### DIFF
--- a/include/can/can.h
+++ b/include/can/can.h
@@ -62,7 +62,7 @@ typedef struct {
     uint8_t data[8];
 } mob_t;
 
-extern uint8_t boffit_count;
+extern volatile uint8_t boffit_count;
 
 
 void init_can(void);
@@ -75,5 +75,8 @@ void resume_mob(mob_t*);
 uint8_t is_paused(mob_t*);
 
 uint8_t mob_status(mob_t*);
+void select_mob(uint8_t);
+
+void set_can_baud_rate(can_baud_rate_t);
 
 #endif

--- a/include/can/can.h
+++ b/include/can/can.h
@@ -8,7 +8,6 @@
 typedef enum {
     TX_MOB,
     RX_MOB,
-    AUTO_MOB
 } mob_type_t;
 
 typedef enum {
@@ -19,6 +18,7 @@ typedef enum {
     CAN_RATE_1000,
 } can_baud_rate_t;
 
+// Define the default baud rate as 100
 #define CAN_DEF_BAUD_RATE CAN_RATE_100
 
 // allows access to the id via table
@@ -41,7 +41,6 @@ typedef struct {
 // TODO: change these; ide_mask SHOULD matter
 #define default_rx_ctrl { 0, 0, 0, 0, 0, 0 }
 #define default_tx_ctrl { 0, 0, 0, 0, 0, 0 }
-#define default_auto_ctrl {1, 0, 0, 0, 0, 0, 1} // RTR, RPLV bits are set
 
 typedef void (*can_rx_callback_t)(const uint8_t*, uint8_t);
 typedef void (*can_tx_callback_t)(uint8_t*, uint8_t*);
@@ -70,7 +69,6 @@ void init_can(void);
 
 void init_rx_mob(mob_t*);
 void init_tx_mob(mob_t*);
-void init_auto_mob(mob_t*);
 
 void pause_mob(mob_t*);
 void resume_mob(mob_t*);

--- a/include/can/can.h
+++ b/include/can/can.h
@@ -11,6 +11,16 @@ typedef enum {
     AUTO_MOB
 } mob_type_t;
 
+typedef enum {
+    CAN_RATE_100,
+    CAN_RATE_125,
+    CAN_RATE_250,
+    CAN_RATE_500,
+    CAN_RATE_1000,
+} can_baud_rate_t;
+
+#define CAN_DEF_BAUD_RATE CAN_RATE_100
+
 // allows access to the id via table
 typedef union {
     uint16_t std;
@@ -31,6 +41,7 @@ typedef struct {
 // TODO: change these; ide_mask SHOULD matter
 #define default_rx_ctrl { 0, 0, 0, 0, 0, 0 }
 #define default_tx_ctrl { 0, 0, 0, 0, 0, 0 }
+#define default_auto_ctrl {1, 0, 0, 0, 0, 0, 1} // RTR, RPLV bits are set
 
 typedef void (*can_rx_callback_t)(const uint8_t*, uint8_t);
 typedef void (*can_tx_callback_t)(uint8_t*, uint8_t*);
@@ -51,6 +62,9 @@ typedef struct {
     can_tx_callback_t tx_data_cb;
     uint8_t data[8];
 } mob_t;
+
+extern uint8_t boffit_count;
+
 
 void init_can(void);
 

--- a/manual_tests/can_boffit_test/can_boffit_test.c
+++ b/manual_tests/can_boffit_test/can_boffit_test.c
@@ -1,0 +1,157 @@
+/*
+CAN Error Modes Test
+
+Authors: Jack Berezny, Andy Xie
+
+Note: Board 2 can be inactive (i.e. not connected to CAN bus), as it can be more straightforward to run with "no ack" errors
+than errors via setting bits.
+Note: In order for this test to run successfully, CANREC and CANTEC must be reset to zero before initialization.
+This can be accomplished by running other code (e.g. can_print_rx, tx), as these registers are read-only and cannot be set directly.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <uart/uart.h>
+#include <can/can.h>
+
+void tx_callback(uint8_t*, uint8_t*);
+void rx_callback(const uint8_t*, uint8_t);
+void error_active_test(void);
+void error_passive_test_tx(void);
+void bus_off_test(void);
+void create_tx_error(void);
+void create_rx_error(void);
+
+mob_t tx_mob = {
+    .mob_num = 0,
+    .mob_type = TX_MOB,
+    .id_tag = { 0x0000 },
+    .ctrl = default_tx_ctrl,
+    .tx_data_cb = tx_callback
+};
+
+mob_t rx_mob = {
+    .mob_num = 1,
+    .mob_type = RX_MOB,
+    .dlc = 7, //alternatively set this to 9 and get errors that way
+    .id_tag = { 0x0000 },
+    .id_mask = { 0x0000 },
+    .ctrl = default_rx_ctrl,
+    .rx_cb = rx_callback
+};
+
+/* Sets data for transmission */
+void tx_callback(uint8_t* data, uint8_t* len) {
+    *len = 7;
+    char str[] = "Hello!";
+
+    for(uint8_t i = 0; i < *len; i++) {
+        data[i] = str[i];
+    }
+}
+
+/* Sets rx callback */
+void rx_callback(const uint8_t* data, uint8_t len) {
+    print("TX received!\n");
+    print("%s\n", (char *) data);
+}
+
+/* Verifies the active error CAN mode (ref. data sheet)*/
+void error_active_test(void){
+    // At this point, CAN should be in error active mode (default)
+    // Verify that CAN is in active error mode (ERRP is low, BOFF set low)
+    print("Start error active\n");
+    print("ERRP: %d\n",ERRP);
+    print("BOFF: %d\n",BOFF);
+
+    if (!(CANGSTA & _BV(ERRP))){
+        print("PASS: ERROR ACTIVE SUCCESS\n");
+    }
+
+    else {
+        print("FAIL: ERROR ACTIVE NOT SUCCESSFUL\n");
+    }
+}
+
+/* Verifies the passive error CAN mode (ref. data sheet)
+   This function tests for Error Passive via tx*/
+void error_passive_test_tx(void){
+    print("Start error passive\n");
+    while(CANTEC < 128){
+        create_tx_error();
+        resume_mob(&tx_mob);
+        while (!is_paused(&tx_mob)) {
+            //wait
+        };
+        print("Msg sent. Tx error count: %d\n", CANTEC);
+    }
+    // At this point, CAN should be in error passive mode due to TX errors
+    // Verify that CAN is in passive error mode (ERRP is high, BOFF set low)
+
+    if (CANGSTA & _BV(ERRP)){
+        print("PASS: ERROR PASSIVE SUCCESS\n");
+    }
+    else {
+        print("FAIL: ERROR PASSIVE NOT SUCCESSFUL\n");
+    }
+}
+
+
+/* Verifies the passive error CAN mode (ref. data sheet)
+   This function tests for Error Passive via rx*/
+
+
+/* Verifies the bus-off CAN mode (ref. data sheet)*/
+void bus_off_test(void){
+    print("Start bus off\n");
+    // Wait until Transmit Error Count (TEC) is greater than 255
+    // Note that 255 is the max value for CANTEC, so after it incremenets
+    // above it will surpass the bus off threshold
+    while(CANTEC < 255){
+        create_tx_error();
+        resume_mob(&tx_mob);
+        while (!is_paused(&tx_mob)) {};
+        print("Msg sent. Rx error count: %d\n", CANREC);
+        print("Msg sent. Tx error count: %d\n", CANTEC);
+        create_tx_error();
+    }
+
+    // Verify that CAN is in bus-off mode(ERRP is high, BOFF set high)
+    if (CANGSTA & _BV(BOFF)){
+        print("PASS: BUS OFF SUCCESS\n");
+    }
+    else {
+        print("FAIL: BUS OFF NOT SUCCESSFUL\n");
+    }
+}
+
+/* NOTE: If setting the registers do not
+ trigger CANTEC or CANREC, can force ack or data length errors manually */
+void create_tx_error(void){
+    // Force bit error (tx only)
+    select_mob(0);
+    CANSTMOB = CANSTMOB | _BV(BERR);
+}
+
+void create_rx_error(void){
+    //force CRC error (rx only)
+    select_mob(1);
+    CANSTMOB = CANSTMOB | _BV(CERR);
+}
+
+int main(void){
+    init_can();
+    init_uart(); //This also initializes uart
+    print("Starting...\n");
+    init_tx_mob(&tx_mob);
+    init_rx_mob(&rx_mob);
+    // Set ERRP, BOFF bits low (should be this by default)
+    CANGSTA &= ~(_BV(ERRP) | _BV(BOFF));
+
+    print("TEST START\n");
+    error_active_test();
+    error_passive_test_tx();
+    bus_off_test();
+    print("TESTS COMPLETE\n");
+    return 0;
+}

--- a/manual_tests/can_boffit_test/makefile
+++ b/manual_tests/can_boffit_test/makefile
@@ -1,0 +1,2 @@
+PROG = can_boffit_test
+include ../makefile

--- a/src/can/can.c
+++ b/src/can/can.c
@@ -1,3 +1,7 @@
+/* https://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8209-8-bit%20AVR%20ATmega16M1-32M1-64M1_Datasheet.pdf */
+
+#include <stdio.h> // Need to import these libraries.
+#include <stdlib.h>
 #include <can/can.h>
 #include <uart/uart.h>
 
@@ -7,38 +11,74 @@ mob_t* mob_array[6] = {0};
 
 uint8_t boffit_count = 0;
 
+// Selects the relevant mob from the CANPAGE register, in order to access
+// registers that are duplicated for each mob
 static inline void select_mob(uint8_t mob_num) {
     CANPAGE = mob_num << 4;
 }
 
+// Sets Identifier Tag registers
 static inline void set_id_tag(mob_id_tag_t id_tag) {
     CANIDT2 = id_tag.tab[0] << 5;
     CANIDT1 = (id_tag.tab[1] << 5) | (id_tag.tab[0] >> 3);
 }
 
+// Sets Identifier Mask registers
 static inline void set_id_mask(mob_id_mask_t id_mask) {
     CANIDM2 = id_mask.tab[0] << 5;
     CANIDM1 = (id_mask.tab[1] << 5) | (id_mask.tab[0] >> 3);
 }
 
 static inline void set_ctrl_flags(mob_ctrl_t ctrl) {
-    if (ctrl.ide) CANCDMOB |= _BV(IDE); // this should never happen
-    else CANCDMOB &= ~(_BV(IDE)); // set the IDE bit to 0, since we're using rev A
+    // The IDE bit sets the CAN version
+    if (ctrl.ide) {
+        CANCDMOB |= _BV(IDE); // this should never happen (version B)
+    }
 
-    if (ctrl.ide_mask) CANIDM4 |= _BV(IDEMSK);
-    else CANIDM4 &= ~(_BV(IDEMSK));
+    else {
+        CANCDMOB &= ~(_BV(IDE)); // Version 2.0 A
+    }
 
-    if (ctrl.rtr_mask) CANIDM4 |= _BV(RTRMSK);
-    else CANIDM4 &= ~(_BV(RTRMSK));
+    // RB0 bit of the remote or data frame to send (updated with value of received frame)
+    if (ctrl.ide_mask) {
+        CANIDM4 |= _BV(IDEMSK); // Bit comparison enabled
+    }
+    else {
+        CANIDM4 &= ~(_BV(IDEMSK)); // Comparison true forced
+    }
 
-    if (ctrl.rtr) CANIDT4 |= _BV(RTRTAG);
-    else CANIDT4 &= ~(_BV(RTRTAG));
+    // Remote Transmission Request Mask
+    if (ctrl.rtr_mask) {
+        CANIDM4 |= _BV(RTRMSK); // Bit comparison enabled
+    }
+    else {
+        CANIDM4 &= ~(_BV(RTRMSK)); // Comparison true forced
+    }
 
-    if (ctrl.rbn_tag) CANIDT4 |= _BV(RB0TAG);
-    else CANIDT4 &= ~(_BV(RB0TAG));
+    // Remote Transmission Request
+    if (ctrl.rtr) {
+        CANIDT4 |= _BV(RTRTAG); // 1 for remote frames (no data)
+    }
+    else {
+        CANIDT4 &= ~(_BV(RTRTAG)); // 0 for data frames
+    }
 
-    if (ctrl.rplv) CANCDMOB |= _BV(RPLV);
-    else CANCDMOB &= ~(_BV(RPLV));
+    // Reserved Bit 0 Tag (updated with value of received frame)
+    if (ctrl.rbn_tag) {
+        CANIDT4 |= _BV(RB0TAG);
+    }
+    else {
+        CANIDT4 &= ~(_BV(RB0TAG));
+    }
+
+    // Used in the automatic reply mode after receiving a remote frame
+    // Since we do not use auto-mobs, this should always be 0
+    if (ctrl.rplv) {
+        CANCDMOB |= _BV(RPLV); // Reply ready and valid
+    }
+    else {
+        CANCDMOB &= ~(_BV(RPLV)); // Reply not ready
+    }
 }
 
 uint8_t load_data(mob_t* mob) {
@@ -59,10 +99,11 @@ uint8_t load_data(mob_t* mob) {
     return len;
 }
 
+// Tests to see if the selected mob is paused
 uint8_t is_paused(mob_t* mob) {
     select_mob(mob->mob_num);
 
-    // the MOb is paused iff the upper two bits of CANCDMOB are 0
+    // the MOb is paused iff the two MSB of CANCDMOB are 0
     if (CANCDMOB & 0xc0) {
         return 0;
     } else {
@@ -70,14 +111,14 @@ uint8_t is_paused(mob_t* mob) {
     }
 }
 
-void init_can() {
+// Initializes CAN protocol
+void init_can(void) {
+    // Reset CAN controller and set communication baud rate to default (100 kbps)
+    void set_can_baud_rate(can_baud_rate_t baud_rate); // Need to formally declare this function first.
     CANGCON |= _BV(SWRES);
-
-    // TODO: figure out why these settings work, and why they weren't working
-    // earlier. These settings are taken directly from the 32m1 datasheet,
-    // pg 240
     set_can_baud_rate(CAN_DEF_BAUD_RATE);
 
+<<<<<<< HEAD
 
 <<<<<<< HEAD
     CANGIE |= _BV(ENIT) | _BV(ENTX) | _BV(ENRX) | _BV(ENERR);
@@ -85,6 +126,9 @@ void init_can() {
     CANGIE |= _BV(ENIT) | _BV(ENBOFF) |_BV(ENTX) | _BV(ENRX) | _BV(ENERR);
     //TODO: deal with error interrupts? - BOFFIT
 >>>>>>> b2507a5... Custom baud rate and BOFFIT Interrupt Handling
+=======
+    CANGIE |= _BV(ENIT) | _BV(ENBOFF) | _BV(ENRX) |  _BV(ENTX) |  _BV(ENERR);
+>>>>>>> 802e49e... Added documentation to the CAN library code and removed references to automobs
     // enable most CAN interrupts, execept the overrun timer, and general errors
 
     // disable all mobs, clear all interrupt flags
@@ -94,20 +138,32 @@ void init_can() {
         CANSTMOB = 0x00;
     }
 
+    // set global interrupt flag
     sei();
 
+    // set can to enable mode
     CANGCON |= _BV(ENASTB);
     while (!(CANGSTA & _BV(ENFG))) {}
     // enable CAN and wait for CAN to turn on before returning
+<<<<<<< HEAD
+=======
+    // added a timeout for this infinite loop
+>>>>>>> 802e49e... Added documentation to the CAN library code and removed references to automobs
 }
 
+// Pauses the selected mob by setting 2 MSB of CANCDMOB to 0
 void pause_mob(mob_t* mob) {
     select_mob(mob->mob_num);
-
-    CANCDMOB &= ~(_BV(CONMOB0) | _BV(CONMOB1));
+    switch (mob->mob_type) {
+        case TX_MOB:
+            CANCDMOB &= ~(_BV(CONMOB0) | _BV(CONMOB1));
+            break;
+        case RX_MOB: // RX mob should not be paused
+            break;
+        }
 }
 
-
+// Resumes the selected mob
 void resume_mob(mob_t* mob) {
     select_mob(mob->mob_num);
 
@@ -119,24 +175,32 @@ void resume_mob(mob_t* mob) {
             CANCDMOB |= _BV(CONMOB0);
             CANCDMOB &= ~(_BV(CONMOB1));
             break;
+        // It is not necessary to resume the RX mob, as it should not be paused.
+        // However, this is called in the init_rx function
         case RX_MOB:
-        case AUTO_MOB:
-            CANCDMOB |= _BV(CONMOB1);
             CANCDMOB &= ~(_BV(CONMOB0));
-            break;
+            CANCDMOB |= _BV(CONMOB1);
     }
 }
 
+// Initializes RX mob
 void init_rx_mob(mob_t* mob) {
     select_mob(mob->mob_num);
 
+    // Sets ID tags, masks, and ctrl flags
     set_id_tag(mob->id_tag);
     set_id_mask(mob->id_mask);
     set_ctrl_flags(mob->ctrl);
 
+    // Sets data length, ranging from 0 to 8, as defined in rx_mob struct
+    // If the number is greater than 8, it may interfere with other CANCDMOB bits
+    if (mob->dlc > 8){
+        mob->dlc = 8;
+    }
     CANCDMOB |= mob->dlc;
 
-    // enable the required interrupts
+    // enable global RX interrupts and interrupts for selected mob
+    // NOTE: This is redundant with init_can
     CANGIE |= _BV(ENRX);
     CANIE2 |= _BV(mob->mob_num);
 
@@ -144,44 +208,33 @@ void init_rx_mob(mob_t* mob) {
     mob_array[mob->mob_num] = mob;
 
     // does this do anything, since the appropriate case is empty?
+    // Case is now filled in, test if below line is necessary
     resume_mob(mob); // enable mob
 }
 
+// Initializes TX mob
 void init_tx_mob(mob_t* mob) {
     select_mob(mob->mob_num);
 
+    // Sets ID tags, masks, and ctrl flags
     set_id_tag(mob->id_tag);
     set_ctrl_flags(mob->ctrl);
+    // Remote frame, so dlc is 0
     mob->dlc = 0;
 
+    // enable global TX interrupts and interrupts on selected mob
+    // NOTE: This is redundant with init_can
     CANGIE |= _BV(ENTX);
     CANIE2 |= _BV(mob->mob_num);
 
+    // add mob to mob_list
     mob_array[mob->mob_num] = mob;
-    pause_mob(mob); // tx mobs must be resumed manually
+    // tx mobs must be resumed manually
+    pause_mob(mob);
 }
 
-void init_auto_mob(mob_t* mob) {
-    select_mob(mob->mob_num);
 
-    set_id_tag(mob->id_tag);
-    set_id_mask(mob->id_mask);
-    set_ctrl_flags(mob->ctrl);
-
-    // TODO: this data might be stale
-    // ideally, you'd load the data just before the auto-reply was sent
-    // In order to avoid stale data, we should develop a timer-triggered load
-    load_data(mob);
-
-    CANGIE |= _BV(ENTX); /* auto-reply mobs only generate tx interrupts */
-    CANIE2 |= _BV(mob->mob_num);
-
-    mob_array[mob->mob_num] = mob;
-    /* The below line may not be necessary, as it transmits only upon reciept of an appropriate msg
-     and behaves as an rx mob until then.  */
-    //pause_mob(mob);
-}
-
+// Handles interrupts for RX mobs
 void handle_rx_interrupt(mob_t* mob) {
     select_mob(mob->mob_num);
 
@@ -192,17 +245,24 @@ void handle_rx_interrupt(mob_t* mob) {
     set_ctrl_flags(mob->ctrl);
 
     uint8_t len = CANCDMOB & 0x0F;
-    mob->dlc = (len >= 8) ? 8 : len;
+    if (len > 8){
+        len = 8;
+    }
+    mob->dlc = len;
 
     CANPAGE &= ~(0x07); // reset data buffer index
 
+    // Reads data from CANMSG
+    // reading auto-increments the data buffer index
     for (uint8_t j = 0; j < len; j++) {
-        (mob->data)[j] = CANMSG; // reading auto-increments the data buffer index
+        (mob->data)[j] = CANMSG;
     }
 
-    (mob->rx_cb)(mob->data, len); // execute callback
+    // executes rx callback
+    (mob->rx_cb)(mob->data, len);
 
-    CANSTMOB &= ~(_BV(RXOK));  // clear interrupt flag
+    // clear interrupt flag
+    CANSTMOB &= ~(_BV(RXOK));
 
     if (mob->mob_type == TX_MOB) pause_mob(mob);
     else resume_mob(mob);
@@ -210,20 +270,8 @@ void handle_rx_interrupt(mob_t* mob) {
     // required because ENMOB is reset after RXOK goes high
 }
 
+// Handles interrupts for TX mobs
 void handle_tx_interrupt(mob_t* mob) {
-    /* TODO: Add some kind of burst mode, which looks like:
-    // Try to load more data automatically
-    load_data(mob);
-
-    select_mob(mob->mob_num);
-    CANSTMOB &= ~(_BV(TXOK));  // clear interrupt flag
-
-    // if we successfully loaded more data, resume (but without calling
-    // load_data)
-
-    if (mob->dlc != 0) resume_mob(mob);
-    else pause_mob(mob);
-    */
 
     select_mob(mob->mob_num);
     CANSTMOB &= ~(_BV(TXOK));  // clear interrupt flag
@@ -233,45 +281,14 @@ void handle_tx_interrupt(mob_t* mob) {
     pause_mob(mob);
 }
 
-void handle_auto_tx_interrupt(mob_t* mob) {
-    select_mob(mob->mob_num);
-
-    // TODO: Many of the variables, including IDTAG, dlc, etc
-    // are copied from the incoming remote frame; thus, they must all be
-    // reset and restored to their original values
-    // In particular, the RTR tag and RPLV bit must be reset to their
-    // original values
-    // as in the TX case, if there is no data left, pause the mob
-    // otherwise, load fresh data via tx callback
-
-    // NOTE: RTR, RPLV are reset automatically
-
-    // TODO: maybe make this work like TX MObs?
-
-    /*load_data(mob);*/
-    // This line likely does not have the intended effect, as the data is  re-loaded
-    // after the message has been transmitted. The data should be updated via other
-    // means, such as being triggered by a timer.
-
-    // clear interrupt flag
-    CANSTMOB &= ~(_BV(TXOK));
-
-    // this should happen all at once (NOTE: This was removed from tx_mob interrupt,
-    // so it is possible that this is not needed here anymore)
-    if (mob->dlc != 0) resume_mob(mob);
-    else pause_mob(mob);
-
-    // TODO: for some reason, we need to set these AFTER
-    set_id_tag(mob->id_tag);
-    set_id_mask(mob->id_mask);
-    set_ctrl_flags(mob->ctrl);
-}
-
+// Returns contents of CANSTMOB register
 uint8_t mob_status(mob_t* mob) {
     select_mob(mob->mob_num);
     return CANSTMOB;
 }
 
+// Prints error statements
+// Most errors are handled by automatically by CAN
 uint8_t handle_err(mob_t* mob) {
     select_mob(mob->mob_num);
 
@@ -292,44 +309,48 @@ uint8_t handle_err(mob_t* mob) {
             print(ERR_MSG, "No ack");
         }
 
-        // TODO: is this the best way to handle errors?
+        // Clears CANSTMOB error bits
         CANSTMOB &= ~(0x9f);
         return 1;
     }
 
     return 0;
 }
+
+// Sets baud rate for CAN (pg. 240 of data sheet)
 void set_can_rate_reg(uint8_t canbt1, uint8_t canbt2, uint8_t canbt3){
     CANBT1 = canbt1;
     CANBT2 = canbt2;
     CANBT3 = canbt3;
 }
 
+// Pre-defined settings for baud rate. 100 is the default.
 void set_can_baud_rate(can_baud_rate_t baud_rate){
-
 switch (baud_rate) {
-    case CAN_RATE_100,:
+    case CAN_RATE_100:
         set_can_rate_reg(8, 12, 55);
         break;
     case CAN_RATE_125:
         set_can_rate_reg(6, 12, 55);
         break;
-    case CAN_RATE_250,:
+    case CAN_RATE_250:
         set_can_rate_reg(2, 12, 55);
         break;
-    case CAN_RATE_500,:
+    case CAN_RATE_500:
         set_can_rate_reg(0, 12, 54);
         break;
-    case CAN_RATE_1000,:
+    case CAN_RATE_1000:
         set_can_rate_reg(0, 4, 18);
         break;
     default:
         break;
 }
 }
-
+// Handles the circumstance where the CAN channel is not allowed to have
+// any influence on bus (i.e. entering bus off mode)
+// Reference pg. 237 for error management
 void handle_bus_off_interrupt(mob_t* mob) {
-    select_mob(mob->mob_num) //not sure if this is necessary
+    select_mob(mob->mob_num); //not sure if this is necessary
 
     CANGIT |= _BV(BOFFIT); //setting this bit clears it
 
@@ -342,7 +363,7 @@ void handle_bus_off_interrupt(mob_t* mob) {
         print("Resetting CAN controller...");
         CANGCON |= _BV(SWRES); // Only resets CAN controller
         CANGCON |= _BV(ENASTB); // Enable mode (0x02)
-        while (!(CANGSTA & _BV(ENFG)){ // Wait until enabled
+        while (!(CANGSTA & _BV(ENFG))){ // Wait until enabled
             print("Waiting...");
         }
         print("Node enabled...");
@@ -353,7 +374,7 @@ void handle_bus_off_interrupt(mob_t* mob) {
     }
 
     else {
-        print("Standby mode...")
+        print("Standby mode...");
         CANGCON |= _BV(SWRES); // Only resets CAN controller
         CANGCON |= ~(_BV(ENASTB)); // Disable node (0x02)
     }
@@ -365,30 +386,33 @@ void handle_bus_off_interrupt(mob_t* mob) {
     // Software reset: CANGCON |= _BV(SWRES); (this resets CAN controller)
 
 }
+
+// ISR routine for CAN to handle various interrupts
 ISR(CAN_INT_vect) {
     for (uint8_t i = 0; i < 6; i++) {
         mob_t* mob = mob_array[i];
-
-        if (mob == 0) continue;
-        else select_mob(i);
+        if (mob == 0) {continue;}
+        else {select_mob(i);}
 
         uint8_t status = mob_status(mob);
 
-        if (handle_err(mob)) continue;
+        if (handle_err(mob)) {continue;}
 
+        // Bus off interrupt
         if (CANGIT & _BV(BOFFIT)){
             handle_bus_off_interrupt(mob);
         }
 
+        // RX interrupts
         if (status & _BV(RXOK)) {
             handle_rx_interrupt(mob);
-        } else if (status & _BV(TXOK)) {
+        }
+
+        // TX interrupts
+        else if (status & _BV(TXOK)) {
             switch (mob->mob_type) {
                 case TX_MOB:
                     handle_tx_interrupt(mob);
-                    break;
-                case AUTO_MOB:
-                    handle_auto_tx_interrupt(mob);
                     break;
                 default:
                     // should never get here


### PR DESCRIPTION
Major changes:
- CAN now has the ability to set custom baud rates and handle bus-off interrupts
- Code for bus-off mode test is included as well and can successfully verify functionality